### PR TITLE
feat: add cookTime field to Recipe model

### DIFF
--- a/pkg/services/cleaner/cleaner.py
+++ b/pkg/services/cleaner/cleaner.py
@@ -418,7 +418,7 @@ def pretty_print_timedelta(t: timedelta, max_components=None, max_decimal_places
     return " ".join(out_list)
 
 
-def clean_category_like(category: str | list) -> list[str]:
+def clean_category_like(category: str | list | None) -> list[str]:
     """
     Cleans a string or list of strings or objects into a list of strings.
 

--- a/pkg/services/recipes/recipe.py
+++ b/pkg/services/recipes/recipe.py
@@ -66,6 +66,7 @@ class Recipe(BaseModel):
 
     prepTime: str | None = None
     performTime: str | None = None
+    cookTime: str | None = None
     totalTime: str | None = None
 
     dateModified: DateLike | None = None

--- a/tests/endpoint/snapshots/cooking.nytimes.com__1015819-chocolate-chip-cookies.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__1015819-chocolate-chip-cookies.json
@@ -53,6 +53,7 @@
     "recipeYield": "1 1/2 dozen 5-inch cookies",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": "45 Minutes",
     "dateModified": null,
     "datePublished": null,

--- a/tests/endpoint/snapshots/cooking.nytimes.com__1023460-challah-bread.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__1023460-challah-bread.json
@@ -87,6 +87,7 @@
     "recipeYield": "1 large loaf",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": "7 Hours 20 Minutes",
     "dateModified": "2023-10-16T21:09:42Z",
     "datePublished": "2022-09-14",

--- a/tests/endpoint/snapshots/cooking.nytimes.com__4735-old-fashioned-beef-stew.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__4735-old-fashioned-beef-stew.json
@@ -54,6 +54,7 @@
     "recipeYield": "4 servings",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "2 Hours 30 Minutes",
     "totalTime": "2 Hours 45 Minutes",
     "dateModified": "2023-11-29T19:38:07Z",
     "datePublished": "1994-01-30",

--- a/tests/endpoint/snapshots/delightbaking.com__little-fluffy-dinner-rolls.json
+++ b/tests/endpoint/snapshots/delightbaking.com__little-fluffy-dinner-rolls.json
@@ -34,6 +34,7 @@
     "recipeYield": "20 rolls",
     "prepTime": "45 Minutes",
     "performTime": null,
+    "cookTime": "15 Minutes",
     "totalTime": "3 Hours 45 Minutes",
     "dateModified": null,
     "datePublished": "2020-07-27T22:10:00+02:00",

--- a/tests/endpoint/snapshots/food52.com__65940-gingerbread-dough-for-houses.json
+++ b/tests/endpoint/snapshots/food52.com__65940-gingerbread-dough-for-houses.json
@@ -63,6 +63,7 @@
     "recipeYield": "makes about 4 pounds (1.80 kg) dough (enough for one medium house - make two batches for larger projects)",
     "prepTime": "2 Hours 30 Minutes",
     "performTime": null,
+    "cookTime": "20 Minutes",
     "totalTime": null,
     "dateModified": "2021-01-02",
     "datePublished": "2016-12-02",

--- a/tests/endpoint/snapshots/leelalicious.com__earl-grey-tea-cake.json
+++ b/tests/endpoint/snapshots/leelalicious.com__earl-grey-tea-cake.json
@@ -66,6 +66,7 @@
     "recipeYield": "12 slices",
     "prepTime": "40 Minutes",
     "performTime": null,
+    "cookTime": "1 Hour",
     "totalTime": "1 Hour 40 Minutes",
     "dateModified": null,
     "datePublished": "2020-05-02T14:46:00Z",

--- a/tests/endpoint/snapshots/preppykitchen.com__chocolate-chip-banana-bread.json
+++ b/tests/endpoint/snapshots/preppykitchen.com__chocolate-chip-banana-bread.json
@@ -60,6 +60,7 @@
     "recipeYield": "10 servings",
     "prepTime": "10 Minutes",
     "performTime": null,
+    "cookTime": "1 Hour",
     "totalTime": "1 Hour 25 Minutes",
     "dateModified": null,
     "datePublished": "2019-10-06T00:00:51Z",

--- a/tests/endpoint/snapshots/prettysimplesweet.com__chocolate-buns-2.json
+++ b/tests/endpoint/snapshots/prettysimplesweet.com__chocolate-buns-2.json
@@ -47,6 +47,7 @@
     "recipeYield": "20 small buns",
     "prepTime": "20 Minutes",
     "performTime": null,
+    "cookTime": "20 Minutes",
     "totalTime": "3 Hours 40 Minutes",
     "dateModified": null,
     "datePublished": "2022-07-14T07:02:00Z",

--- a/tests/endpoint/snapshots/sallysbakingaddiction.com__spinach-bacon-breakfast-strata.json
+++ b/tests/endpoint/snapshots/sallysbakingaddiction.com__spinach-bacon-breakfast-strata.json
@@ -67,6 +67,7 @@
     "recipeYield": "serves 10-12",
     "prepTime": "1 Hour 30 Minutes",
     "performTime": null,
+    "cookTime": "55 Minutes",
     "totalTime": "2 Hours 30 Minutes",
     "dateModified": null,
     "datePublished": "2021-03-27",

--- a/tests/endpoint/snapshots/thedomesticrebel.com__levain-bakery-style-ultimate-peanut-butter-cookies.json
+++ b/tests/endpoint/snapshots/thedomesticrebel.com__levain-bakery-style-ultimate-peanut-butter-cookies.json
@@ -51,6 +51,7 @@
     "recipeYield": "9 cookies",
     "prepTime": "20 Minutes",
     "performTime": null,
+    "cookTime": "13 Minutes",
     "totalTime": "33 Minutes",
     "dateModified": null,
     "datePublished": "2021-04-28T01:00:27Z",

--- a/tests/endpoint/snapshots/themodernproper.com__thai-basil-beef.json
+++ b/tests/endpoint/snapshots/themodernproper.com__thai-basil-beef.json
@@ -63,6 +63,7 @@
     "recipeYield": "4",
     "prepTime": "10 Minutes",
     "performTime": null,
+    "cookTime": "15 Minutes",
     "totalTime": "25 Minutes",
     "dateModified": "2023-09-15T15:28:41-07:00",
     "datePublished": "2020-01-05T21:53:52-08:00",

--- a/tests/endpoint/snapshots/therecipecritic.com__crispy-parmesan-garlic-chicken-zucchini.json
+++ b/tests/endpoint/snapshots/therecipecritic.com__crispy-parmesan-garlic-chicken-zucchini.json
@@ -42,6 +42,7 @@
     "recipeYield": "4 Servings",
     "prepTime": "5 Minutes",
     "performTime": null,
+    "cookTime": "20 Minutes",
     "totalTime": "25 Minutes",
     "dateModified": null,
     "datePublished": "2021-08-04T18:00:00Z",

--- a/tests/endpoint/snapshots/www.bonappetit.com__adult-mac-and-cheese.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__adult-mac-and-cheese.json
@@ -65,6 +65,7 @@
     "recipeYield": "4 servings",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": null,
     "dateModified": "2019-01-15T15:35:00-05:00",
     "datePublished": "2019-01-13T04:00:00-05:00",

--- a/tests/endpoint/snapshots/www.bonappetit.com__best-pumpkin-pie.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__best-pumpkin-pie.json
@@ -56,6 +56,7 @@
     "recipeYield": "Makes one 9\" pie",
     "prepTime": null,
     "performTime": null,
+    "cookTime": "1 hour",
     "totalTime": "2 hours (plus 4 hours 30 minutes for chilling)",
     "dateModified": "2023-09-06T11:34:00-04:00",
     "datePublished": "2016-11-13T08:00:00-05:00",

--- a/tests/endpoint/snapshots/www.bonappetit.com__cabbage-roll-casserole.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__cabbage-roll-casserole.json
@@ -79,6 +79,7 @@
     "recipeYield": "6\u20138 servings",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": null,
     "dateModified": "2021-02-14T04:00:00-05:00",
     "datePublished": "2021-02-14T04:00:00-05:00",

--- a/tests/endpoint/snapshots/www.bonappetit.com__cheesesteaks.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__cheesesteaks.json
@@ -63,6 +63,7 @@
     "recipeYield": "8  Servings",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": null,
     "dateModified": "2017-01-10T08:00:00-05:00",
     "datePublished": "2017-01-10T08:00:00-05:00",

--- a/tests/endpoint/snapshots/www.bonappetit.com__chicken-scarpariello.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__chicken-scarpariello.json
@@ -59,6 +59,7 @@
     "recipeYield": "4 servings",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": null,
     "dateModified": "2017-09-26T12:31:13.485000-04:00",
     "datePublished": "2017-09-26T12:31:13.485000-04:00",

--- a/tests/endpoint/snapshots/www.bonappetit.com__easiest-chicken-adobo.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__easiest-chicken-adobo.json
@@ -67,6 +67,7 @@
     "recipeYield": "4 servings",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": null,
     "dateModified": "2017-10-16T06:00:00-04:00",
     "datePublished": "2017-10-16T06:00:00-04:00",

--- a/tests/endpoint/snapshots/www.bonappetit.com__grilled-chicken-tacos.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__grilled-chicken-tacos.json
@@ -48,6 +48,7 @@
     "recipeYield": "4  Servings",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": null,
     "dateModified": "2013-06-04T20:00:00-04:00",
     "datePublished": "2013-06-04T20:00:00-04:00",

--- a/tests/endpoint/snapshots/www.bonappetit.com__mama-rosas-lasagna-de-carne.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__mama-rosas-lasagna-de-carne.json
@@ -73,6 +73,7 @@
     "recipeYield": "8 - 10 Servings",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": null,
     "dateModified": "2021-11-23T06:00:00-05:00",
     "datePublished": "2021-11-23T06:00:00-05:00",

--- a/tests/endpoint/snapshots/www.bonappetit.com__roasted-broccoli.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__roasted-broccoli.json
@@ -39,6 +39,7 @@
     "recipeYield": "4 to 6 Servings",
     "prepTime": null,
     "performTime": null,
+    "cookTime": "5 minutes",
     "totalTime": "40 minutes",
     "dateModified": "2022-12-21T16:02:00-05:00",
     "datePublished": "2015-11-12T06:40:34-05:00",

--- a/tests/endpoint/snapshots/www.bonappetit.com__seafood-chowder.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__seafood-chowder.json
@@ -58,6 +58,7 @@
     "recipeYield": "Makes about 8 quarts",
     "prepTime": null,
     "performTime": null,
+    "cookTime": "20 minutes",
     "totalTime": "25 minutes",
     "dateModified": "2023-09-18T17:51:00-04:00",
     "datePublished": "2020-04-14T04:00:00-04:00",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__beef-cabbage-stir-fry.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__beef-cabbage-stir-fry.json
@@ -46,6 +46,7 @@
     "recipeYield": "4 (1.5 cups each)",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "15 Minutes",
     "totalTime": "30 Minutes",
     "dateModified": null,
     "datePublished": "2016-08-29T15:29:10Z",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__easy-pesto-chicken-and-vegetables.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__easy-pesto-chicken-and-vegetables.json
@@ -61,6 +61,7 @@
     "recipeYield": "4 1.5 cups each",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "15 Minutes",
     "totalTime": "30 Minutes",
     "dateModified": null,
     "datePublished": "2021-05-17T16:34:29Z",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__fried-cabbage-and-noodles.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__fried-cabbage-and-noodles.json
@@ -47,6 +47,7 @@
     "recipeYield": "4 about 2 cups each",
     "prepTime": "5 Minutes",
     "performTime": null,
+    "cookTime": "20 Minutes",
     "totalTime": "25 Minutes",
     "dateModified": null,
     "datePublished": "2016-10-08T16:44:52Z",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__one-pot-creamy-cajun-chicken-pasta.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__one-pot-creamy-cajun-chicken-pasta.json
@@ -63,6 +63,7 @@
     "recipeYield": "4",
     "prepTime": "10 Minutes",
     "performTime": null,
+    "cookTime": "20 Minutes",
     "totalTime": "30 Minutes",
     "dateModified": null,
     "datePublished": "2018-10-21T17:07:41Z",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__unstuffed-bell-peppers.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__unstuffed-bell-peppers.json
@@ -65,6 +65,7 @@
     "recipeYield": "6 1 \u2153 cups each",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "45 Minutes",
     "totalTime": "1 Hour",
     "dateModified": null,
     "datePublished": "2021-02-04T11:02:01Z",

--- a/tests/endpoint/snapshots/www.cookingchanneltv.com__baked-potato-fries-reloaded-5470330.json
+++ b/tests/endpoint/snapshots/www.cookingchanneltv.com__baked-potato-fries-reloaded-5470330.json
@@ -48,6 +48,7 @@
     "recipeYield": "4 servings",
     "prepTime": null,
     "performTime": null,
+    "cookTime": "30 Minutes",
     "totalTime": "12 Hours 30 Minutes",
     "dateModified": "2018-10-19T16:02:20.127000-04:00",
     "datePublished": "2018-10-19T16:02:20.427000-04:00",

--- a/tests/endpoint/snapshots/www.delish.com__creamy-tuscan-chicken-recipe.json
+++ b/tests/endpoint/snapshots/www.delish.com__creamy-tuscan-chicken-recipe.json
@@ -59,6 +59,7 @@
     "recipeYield": "4 serving(s)",
     "prepTime": "5 Minutes",
     "performTime": null,
+    "cookTime": "none",
     "totalTime": "40 Minutes",
     "dateModified": "2023-12-21T03:48:00Z",
     "datePublished": "2018-04-03T18:15:44.644694Z",

--- a/tests/endpoint/snapshots/www.ethanchlebowski.com__grams-buns-the-greatest-bread-roll.json
+++ b/tests/endpoint/snapshots/www.ethanchlebowski.com__grams-buns-the-greatest-bread-roll.json
@@ -39,6 +39,7 @@
     "recipeYield": "8-10 Buns",
     "prepTime": "25 Minutes",
     "performTime": null,
+    "cookTime": "10 Minutes",
     "totalTime": "3 Hours 35 Minutes",
     "dateModified": null,
     "datePublished": null,

--- a/tests/endpoint/snapshots/www.ethanchlebowski.com__kolaches-sweet-amp-savory.json
+++ b/tests/endpoint/snapshots/www.ethanchlebowski.com__kolaches-sweet-amp-savory.json
@@ -15,6 +15,7 @@
     "recipeYield": "",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": null,
     "dateModified": null,
     "datePublished": null,

--- a/tests/endpoint/snapshots/www.foodnetwork.com__baked-macaroni-and-cheese-recipe-1939524.json
+++ b/tests/endpoint/snapshots/www.foodnetwork.com__baked-macaroni-and-cheese-recipe-1939524.json
@@ -66,6 +66,7 @@
     "recipeYield": "6 to 8 servings",
     "prepTime": "20 Minutes",
     "performTime": null,
+    "cookTime": "45 Minutes",
     "totalTime": "1 Hour 5 Minutes",
     "dateModified": "2014-09-29T12:37:33.574000-04:00",
     "datePublished": "2015-07-22T10:03:35.315000-04:00",

--- a/tests/endpoint/snapshots/www.foodnetwork.com__instant-pancake-mix-recipe-1938544.json
+++ b/tests/endpoint/snapshots/www.foodnetwork.com__instant-pancake-mix-recipe-1938544.json
@@ -64,6 +64,7 @@
     "recipeYield": "3 batches of pancakes (12 pancakes)",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": null,
     "dateModified": "2015-01-23T11:50:51.188000-05:00",
     "datePublished": "2015-05-09T09:53:12.564000-04:00",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__brown-butter-oatmeal-chocolate-chip-cookies.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__brown-butter-oatmeal-chocolate-chip-cookies.json
@@ -40,6 +40,7 @@
     "recipeYield": "24 cookies",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "15 Minutes",
     "totalTime": "30 Minutes",
     "dateModified": null,
     "datePublished": "2022-08-19T02:00:00Z",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__chicken-gyros-with-feta-tzatziki.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__chicken-gyros-with-feta-tzatziki.json
@@ -41,6 +41,7 @@
     "recipeYield": "3",
     "prepTime": "30 Minutes",
     "performTime": null,
+    "cookTime": "25 Minutes",
     "totalTime": "55 Minutes",
     "dateModified": null,
     "datePublished": "2022-02-17T02:00:00Z",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__chili-crisp-peanut-noodles.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__chili-crisp-peanut-noodles.json
@@ -44,6 +44,7 @@
     "recipeYield": "6",
     "prepTime": "20 Minutes",
     "performTime": null,
+    "cookTime": "10 Minutes",
     "totalTime": "30 Minutes",
     "dateModified": null,
     "datePublished": "2022-08-08T02:00:00Z",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__creamy-parmesan-chicken-and-spinach-tortellini.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__creamy-parmesan-chicken-and-spinach-tortellini.json
@@ -40,6 +40,7 @@
     "recipeYield": "6",
     "prepTime": "10 Minutes",
     "performTime": null,
+    "cookTime": "20 Minutes",
     "totalTime": "30 Minutes",
     "dateModified": null,
     "datePublished": "2021-03-10T02:00:42Z",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__green-chile-chicken.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__green-chile-chicken.json
@@ -41,6 +41,7 @@
     "recipeYield": "4",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "20 Minutes",
     "totalTime": "40 Minutes",
     "dateModified": null,
     "datePublished": "2022-04-07T02:00:00Z",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__korean-beef-sesame-noodles.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__korean-beef-sesame-noodles.json
@@ -42,6 +42,7 @@
     "recipeYield": "4",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "10 Minutes",
     "totalTime": "25 Minutes",
     "dateModified": null,
     "datePublished": "2022-08-15T02:00:00Z",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__one-pot-hamburger-helper.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__one-pot-hamburger-helper.json
@@ -37,6 +37,7 @@
     "recipeYield": "6",
     "prepTime": "10 Minutes",
     "performTime": null,
+    "cookTime": "20 Minutes",
     "totalTime": "30 Minutes",
     "dateModified": null,
     "datePublished": "2021-09-09T02:00:00Z",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__roasted-red-pepper-chicken-pasta.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__roasted-red-pepper-chicken-pasta.json
@@ -47,6 +47,7 @@
     "recipeYield": "6",
     "prepTime": "25 Minutes",
     "performTime": null,
+    "cookTime": "20 Minutes",
     "totalTime": "45 Minutes",
     "dateModified": null,
     "datePublished": "2022-07-06T02:00:00Z",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__stove-top-mac-and-cheese.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__stove-top-mac-and-cheese.json
@@ -37,6 +37,7 @@
     "recipeYield": "6",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "15 Minutes",
     "totalTime": "30 Minutes",
     "dateModified": null,
     "datePublished": "2022-01-31T02:00:00Z",

--- a/tests/endpoint/snapshots/www.hellofresh.com__uk-balsamic-streak-with-red-cabb-5841a8ad9df18165854cdd72.json
+++ b/tests/endpoint/snapshots/www.hellofresh.com__uk-balsamic-streak-with-red-cabb-5841a8ad9df18165854cdd72.json
@@ -54,6 +54,7 @@
     "recipeYield": "2",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": "40 Minutes",
     "dateModified": null,
     "datePublished": "2016-12-02T17:00:29Z",

--- a/tests/endpoint/snapshots/www.joshuaweissman.com__best-mac-and-cheese-recipe.json
+++ b/tests/endpoint/snapshots/www.joshuaweissman.com__best-mac-and-cheese-recipe.json
@@ -17,6 +17,7 @@
     "recipeYield": "",
     "prepTime": "10-35 minutes",
     "performTime": null,
+    "cookTime": "15 minutes - 1 hour, 20 minutes",
     "totalTime": "25 minutes - 2 hours",
     "dateModified": null,
     "datePublished": null,

--- a/tests/endpoint/snapshots/www.recipetineats.com__greek-chicken-gyros-with-tzatziki.json
+++ b/tests/endpoint/snapshots/www.recipetineats.com__greek-chicken-gyros-with-tzatziki.json
@@ -85,6 +85,7 @@
     "recipeYield": "4 - 6",
     "prepTime": "20 Minutes",
     "performTime": null,
+    "cookTime": "6 Minutes",
     "totalTime": "26 Minutes",
     "dateModified": null,
     "datePublished": "2020-05-24T23:00:00Z",
@@ -110,7 +111,7 @@
       "unit": "pound",
       "comment": "(, boneless skinless)",
       "other": "",
-      "confidence": 0.999847
+      "confidence": 0.999818
     },
     {
       "input": "3 large garlic cloves (, minced (~ 3 tsp))",

--- a/tests/endpoint/snapshots/www.recipetineats.com__naan-recipe.json
+++ b/tests/endpoint/snapshots/www.recipetineats.com__naan-recipe.json
@@ -83,6 +83,7 @@
     "recipeYield": "6",
     "prepTime": "20 Minutes",
     "performTime": null,
+    "cookTime": "10 Minutes",
     "totalTime": null,
     "dateModified": null,
     "datePublished": "2021-02-24T20:41:27Z",
@@ -172,7 +173,7 @@
       "unit": "gram",
       "comment": ", melted",
       "other": "",
-      "confidence": 0.999423
+      "confidence": 0.999812
     },
     {
       "input": "30g / 2 tbsp tbsp ghee or butter (, melted (Note 4))",
@@ -181,7 +182,7 @@
       "unit": "gram",
       "comment": ", melted",
       "other": "",
-      "confidence": 0.999423
+      "confidence": 0.999829
     },
     {
       "input": "1 small garlic clove (, for Garlic Butter option (Note 5))",

--- a/tests/endpoint/snapshots/www.seriouseats.com__copycat-chicken-nuggets-with-sweet-n-sour-sauce.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__copycat-chicken-nuggets-with-sweet-n-sour-sauce.json
@@ -67,6 +67,7 @@
     "recipeYield": "30 nuggets",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "25 Minutes",
     "totalTime": "1 Hour 50 Minutes",
     "dateModified": "2023-05-10T16:39:17.260000-04:00",
     "datePublished": "2020-04-20T09:00:54-04:00",

--- a/tests/endpoint/snapshots/www.seriouseats.com__easy-no-knead-focaccia.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__easy-no-knead-focaccia.json
@@ -48,6 +48,7 @@
     "recipeYield": "8",
     "prepTime": "35 Minutes",
     "performTime": null,
+    "cookTime": "45 Minutes",
     "totalTime": "22 Hours 45 Minutes",
     "dateModified": "2023-12-21T10:03:23.427000-05:00",
     "datePublished": "2020-04-29T06:30:39-04:00",

--- a/tests/endpoint/snapshots/www.seriouseats.com__five-minute-grilled-chicken-cutlet-rosemary-garlic-lemon-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__five-minute-grilled-chicken-cutlet-rosemary-garlic-lemon-recipe.json
@@ -42,6 +42,7 @@
     "recipeYield": "4",
     "prepTime": "5 Minutes",
     "performTime": null,
+    "cookTime": "30 Minutes",
     "totalTime": "35 Minutes",
     "dateModified": "2023-12-21T09:19:36.743000-05:00",
     "datePublished": "2015-09-08T08:45:00-04:00",

--- a/tests/endpoint/snapshots/www.seriouseats.com__ingredient-stovetop-mac-and-cheese-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__ingredient-stovetop-mac-and-cheese-recipe.json
@@ -43,6 +43,7 @@
     "recipeYield": "2",
     "prepTime": null,
     "performTime": null,
+    "cookTime": "15 Minutes",
     "totalTime": "15 Minutes",
     "dateModified": "2023-02-17T11:57:42.054000-05:00",
     "datePublished": "2017-01-09T02:30:00-05:00",

--- a/tests/endpoint/snapshots/www.seriouseats.com__salmon-burgers-remoulade-fennel-slaw-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__salmon-burgers-remoulade-fennel-slaw-recipe.json
@@ -78,6 +78,7 @@
     "recipeYield": "4",
     "prepTime": null,
     "performTime": null,
+    "cookTime": null,
     "totalTime": "40 Minutes",
     "dateModified": "2022-12-22T19:38:29.204000-05:00",
     "datePublished": "2017-04-20T08:50:00-04:00",

--- a/tests/endpoint/snapshots/www.seriouseats.com__spicy-spring-sicilian-pizza-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__spicy-spring-sicilian-pizza-recipe.json
@@ -73,6 +73,7 @@
     "recipeYield": "8",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "35 Minutes",
     "totalTime": "2 Hours 50 Minutes",
     "dateModified": "2022-09-15T15:34:50.667000-04:00",
     "datePublished": "2016-05-13T08:45:00-04:00",

--- a/tests/endpoint/snapshots/www.seriouseats.com__the-best-roast-potatoes-ever-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__the-best-roast-potatoes-ever-recipe.json
@@ -49,6 +49,7 @@
     "recipeYield": "8",
     "prepTime": null,
     "performTime": null,
+    "cookTime": "1 Hour 40 Minutes",
     "totalTime": "1 Hour 40 Minutes",
     "dateModified": "2022-12-19T15:08:48.928000-05:00",
     "datePublished": "2016-12-02T05:15:00-05:00",

--- a/tests/endpoint/snapshots/www.tasteofhome.com__dutch-oven-bread.json
+++ b/tests/endpoint/snapshots/www.tasteofhome.com__dutch-oven-bread.json
@@ -30,6 +30,7 @@
     "recipeYield": "1 loaf (16 pieces).",
     "prepTime": "15 Minutes",
     "performTime": null,
+    "cookTime": "45 Minutes",
     "totalTime": "1 Hour",
     "dateModified": "2023-12-18",
     "datePublished": "2020-07-02",

--- a/tests/endpoint/test_parser_snapshots.py
+++ b/tests/endpoint/test_parser_snapshots.py
@@ -119,6 +119,7 @@ def test_parse_clean(client: TestClient, url: str, name: str) -> None:
     assert recipe.recipeYield == expect_recipe.recipeYield
     assert recipe.prepTime == expect_recipe.prepTime
     assert recipe.performTime == expect_recipe.performTime
+    assert recipe.cookTime == expect_recipe.cookTime
     assert recipe.totalTime == expect_recipe.totalTime
 
     assert recipe.dateModified == expect_recipe.dateModified


### PR DESCRIPTION
## Summary
- Add missing `cookTime` field to Recipe Pydantic model - the cleaner already extracted this from JSON-LD but it was silently dropped
- Add `cookTime` assertion to snapshot tests
- Regenerate snapshots to include cookTime values
- Fix type hint for `clean_category_like` to accept `None`

## Test plan
- [x] All 154 tests pass
- [x] Verified cookTime is correctly parsed from JSON-LD (e.g., `PT20M` → `20 Minutes`)