### PR TITLE
feat: add recipeInstructionSections to preserve HowToSection structure

### DIFF
--- a/pkg/services/recipes/recipe.py
+++ b/pkg/services/recipes/recipe.py
@@ -9,6 +9,15 @@ class Instructions(BaseModel):
     text: str
 
 
+class InstructionStep(BaseModel):
+    text: str
+
+
+class InstructionSection(BaseModel):
+    name: str | None = None
+    steps: list[InstructionStep]
+
+
 class Author(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -50,6 +59,10 @@ class Recipe(BaseModel):
     instructions: list[Instructions] = Field(
         default_factory=list,
         alias="recipeInstructions",
+    )
+    instruction_sections: list[InstructionSection] | None = Field(
+        default=None,
+        alias="recipeInstructionSections",
     )
     ingredients: list[str] = Field(
         default_factory=list,

--- a/tests/endpoint/snapshots/cooking.nytimes.com__1015819-chocolate-chip-cookies.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__1015819-chocolate-chip-cookies.json
@@ -18,6 +18,7 @@
         "text": "Scoop 6 3 1/2-ounce mounds of dough (the size of generous golf balls) onto baking sheet, making sure to turn horizontally any chocolate pieces that are poking up; it will make for a more attractive cookie. Sprinkle lightly with sea salt and bake until golden brown but still soft, 18 to 20 minutes. Transfer sheet to a wire rack for 10 minutes, then slip cookies onto another rack to cool a bit more. Repeat with remaining dough, or reserve dough, refrigerated, for baking remaining batches the next day. Eat warm, with a big napkin."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 cups minus 2 tablespoons cake flour (8 1/2 ounces)",
       "1 2/3 cups bread flour (8 1/2 ounces)",

--- a/tests/endpoint/snapshots/cooking.nytimes.com__1023460-challah-bread.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__1023460-challah-bread.json
@@ -51,6 +51,7 @@
         "text": "Bake: Uncover the challah and brush with another layer of egg wash. Sprinkle the loaf with poppy or sesame seeds (if using) and bake until the loaf is shiny and burnished, an instant-read thermometer registers 190 degrees when inserted into the center, and it sounds hollow when tapped on the bottom, 35 to 40 minutes. Let the challah cool completely on the baking sheet."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 teaspoon active dry yeast",
       "1 1/4 cups/169 grams bread flour",

--- a/tests/endpoint/snapshots/cooking.nytimes.com__4735-old-fashioned-beef-stew.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__4735-old-fashioned-beef-stew.json
@@ -15,6 +15,7 @@
         "text": "Cover and cook, skimming broth from time to time, until the beef is tender, about 1 1/2 hours. Add the onions and carrots and simmer, covered, for 10 minutes. Add the potatoes and simmer until vegetables are tender, about 30 minutes more. Add broth or water if the stew is dry. Season with salt and pepper to taste. Ladle among 4 bowls and serve."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1/4 cup all-purpose flour",
       "1/4 teaspoon freshly ground pepper",

--- a/tests/endpoint/snapshots/delightbaking.com__little-fluffy-dinner-rolls.json
+++ b/tests/endpoint/snapshots/delightbaking.com__little-fluffy-dinner-rolls.json
@@ -5,6 +5,7 @@
     "url": "https://delightbaking.com/little-fluffy-dinner-rolls/",
     "description": "Don't know what to bring to the next party or dinner with your family? Bake some of these little fluffy dinner rolls and everybody will love you!",
     "recipeInstructions": [],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "640 g All-purpose flour",
       "15 g Salt",

--- a/tests/endpoint/snapshots/food52.com__65940-gingerbread-dough-for-houses.json
+++ b/tests/endpoint/snapshots/food52.com__65940-gingerbread-dough-for-houses.json
@@ -33,6 +33,7 @@
         "text": "Let your pieces cool completely before you begin to construct your house."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 1/2 cups shortening, at room temperature (see headnote) (340 g)",
       "1 1/4 cups granulated sugar (250 g)",

--- a/tests/endpoint/snapshots/leelalicious.com__earl-grey-tea-cake.json
+++ b/tests/endpoint/snapshots/leelalicious.com__earl-grey-tea-cake.json
@@ -33,6 +33,7 @@
         "text": "Let the loaf cool to room temperature before slicing into it."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1/2 cup milk",
       "4 Earl Grey tea bags (divided, 2 for steeping; 2 for loose leaves to add to batter )",

--- a/tests/endpoint/snapshots/preppykitchen.com__chocolate-chip-banana-bread.json
+++ b/tests/endpoint/snapshots/preppykitchen.com__chocolate-chip-banana-bread.json
@@ -27,6 +27,7 @@
         "text": "Bake for 60 minutes or until a skewer inserted into the middle comes out clean. Let cool in the pan for 15 minutes, then remove and finish cooling on a wire rack."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1\u00be cups all-purpose flour ((210g))",
       "1 teaspoon baking powder",

--- a/tests/endpoint/snapshots/prettysimplesweet.com__chocolate-buns-2.json
+++ b/tests/endpoint/snapshots/prettysimplesweet.com__chocolate-buns-2.json
@@ -27,6 +27,7 @@
         "text": "Buns are best the same day they are made, but can be frozen for up to 2 months."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "3\u00bd cups (500g) all-purpose flour",
       "3 tablespoons (20g) cocoa powder (I use Dutch process)",

--- a/tests/endpoint/snapshots/sallysbakingaddiction.com__spinach-bacon-breakfast-strata.json
+++ b/tests/endpoint/snapshots/sallysbakingaddiction.com__spinach-bacon-breakfast-strata.json
@@ -36,6 +36,7 @@
         "text": "Cover leftovers tightly and store in the refrigerator for up to 5 days. Reheat in the microwave."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "8 cups (about a 12 ounce loaf) cubed bread (I recommend big chunks of a crispy baguette or sourdough loaf)",
       "8 slices uncooked bacon",

--- a/tests/endpoint/snapshots/thedomesticrebel.com__levain-bakery-style-ultimate-peanut-butter-cookies.json
+++ b/tests/endpoint/snapshots/thedomesticrebel.com__levain-bakery-style-ultimate-peanut-butter-cookies.json
@@ -21,6 +21,7 @@
         "text": "Bake one baking sheet at a time in the center rack of the oven for 10-13 minutes or until the tops are light golden brown and the exterior is dry and dull looking. Centers will be slightly underdone and gooey; this is okay and the cookies will finish cooking some once removed from the oven. Let stand on the baking sheets for at least 30 minutes before serving; the cookies are very delicate and fragile once removed from the oven and need time to set before being moved. Keep remaining dough refrigerated while other cookies bake."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 cup unsalted butter, cut into cubes",
       "1 cup light brown sugar",

--- a/tests/endpoint/snapshots/themodernproper.com__thai-basil-beef.json
+++ b/tests/endpoint/snapshots/themodernproper.com__thai-basil-beef.json
@@ -21,6 +21,7 @@
         "text": "Enjoy!"
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 tbsp olive oil or vegetable oil",
       "1 lb ground beef 90/10",

--- a/tests/endpoint/snapshots/therecipecritic.com__crispy-parmesan-garlic-chicken-zucchini.json
+++ b/tests/endpoint/snapshots/therecipecritic.com__crispy-parmesan-garlic-chicken-zucchini.json
@@ -15,6 +15,7 @@
         "text": "Add 2 Tablespoons of butter back to the skillet and saute the minced garlic for a minute. Add the zucchini to the skillet and saute until tender. Salt and pepper to taste and add 1 Tablespoon parmesan. Add the chicken back to the skillet and heat for a minute or so. Serve immediately."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 Chicken Breasts (sliced in half, or 4 thin chicken breasts)",
       "8 Tablespoons butter (divided)",

--- a/tests/endpoint/snapshots/www.bonappetit.com__adult-mac-and-cheese.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__adult-mac-and-cheese.json
@@ -30,6 +30,7 @@
         "text": "Divide pasta between bowls\u2014or just heap it into one big bowl for yourself, no judgie\u2014and serve right away."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "Kosher salt",
       "1 lb. small shells",

--- a/tests/endpoint/snapshots/www.bonappetit.com__best-pumpkin-pie.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__best-pumpkin-pie.json
@@ -15,6 +15,7 @@
         "text": "Preheat oven to 325\u00b0. Whisk \u2153 cup (67 g) sugar, 1 tsp. ground cinnamon, \u00be tsp. Diamond Crystal or \u00bd tsp. Morton kosher salt, \u00bd tsp. ground ginger, \u00bc tsp. ground cloves, and \u00bc tsp. ground nutmeg in a large bowl until no clumps remain. Add 2 large eggs plus 1 large egg yolk, room temperature, beaten to blend, 2 cups unsweetened pumpkin pur\u00e9e, \u2154 cup sweetened condensed milk, \u2153 cup heavy cream, 2 Tbsp. maple syrup, and 2 tsp. vanilla extract and whisk until smooth. Pour into cooled crust. Bake pie until edges are set and slightly puffed but center is recessed and wobbles like Jell-O, 60\u201375 minutes (it will continue to set after baking). Transfer to a wire rack and let cool at least 3 hours before slicing. Serve with whipped cream.\nDo Ahead: Pie can be baked 1 day ahead; tightly wrap and chill. Serve warm or at room temperature. You can also freeze pumpkin pie up to 3 months in advance.\n\nEditor\u2019s note: This recipe was first printed in November 2016 as part of BA\u2019s Best, a collection of our essential recipes. Head this way for more of our favorite Thanksgiving desserts \u2192"
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 disk Actually Perfect Pie Crust",
       "All-purpose flour, for surface",

--- a/tests/endpoint/snapshots/www.bonappetit.com__cabbage-roll-casserole.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__cabbage-roll-casserole.json
@@ -36,6 +36,7 @@
         "text": "Cover dish with foil and set on a large rimmed baking sheet. Bake 20 minutes. Uncover dish and increase oven temperature to 425\u00b0. Continue to bake until cheese is golden brown and bubbling, 18\u201320 minutes. Let cool 10 minutes before serving.\nDo ahead: Meat sauce can be made, rice can be parboiled, and cabbage leaves can be blanched 3 days ahead. Cover and chill separately. Assemble casserole just before baking."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 large bunch dill",
       "3 large garlic cloves",

--- a/tests/endpoint/snapshots/www.bonappetit.com__cheesesteaks.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__cheesesteaks.json
@@ -27,6 +27,7 @@
         "text": "Do Ahead: Meat can be sliced 1 day ahead (it will start to oxidize after that); cover tightly and chill, or freeze up to 1 week and thaw before cooking. Sandwiches can be made 20 minutes ahead; immediately wrap in parchment paper, then foil."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 tablespoons olive oil",
       "4 large onions, sliced \u00bc inch thick",

--- a/tests/endpoint/snapshots/www.bonappetit.com__chicken-scarpariello.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__chicken-scarpariello.json
@@ -21,6 +21,7 @@
         "text": "Top with parsley and serve with roasted potatoes alongside."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1\u00bd pounds fingerling potatoes, halved lengthwise",
       "6 tablespoons extra-virgin olive oil, divided",

--- a/tests/endpoint/snapshots/www.bonappetit.com__easiest-chicken-adobo.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__easiest-chicken-adobo.json
@@ -30,6 +30,7 @@
         "text": "Serve chicken and sauce over rice. Thinly slice remaining chile and scatter over, then season with more pepper."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 head of garlic",
       "2 green chiles (such as serrano or jalape\u00f1o), divided",

--- a/tests/endpoint/snapshots/www.bonappetit.com__grilled-chicken-tacos.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__grilled-chicken-tacos.json
@@ -12,6 +12,7 @@
         "text": "Let chicken rest 5 minutes before slicing. Serve with tortillas, avocados, Charred Tomatillo Salsa Verde, cilantro, radishes, and lime wedges."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 medium onion, cut into wedges, keeping root intact",
       "2 garlic cloves, finely chopped",

--- a/tests/endpoint/snapshots/www.bonappetit.com__mama-rosas-lasagna-de-carne.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__mama-rosas-lasagna-de-carne.json
@@ -21,6 +21,7 @@
         "text": "Bake lasagna until bubbling around the edges, 40\u201345 minutes. Increase oven temperature to 425\u00b0. Uncover lasagna and continue to bake until top is golden brown, 15\u201318 minutes more. Let sit 15 minutes before serving.\nDo Ahead: Lasagna can be baked 3 days ahead. Let cool; cover and chill. Reheat in a 250\u00b0 oven."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "\u00bd red bell pepper, coarsely chopped",
       "1 small onion, coarsely chopped",

--- a/tests/endpoint/snapshots/www.bonappetit.com__roasted-broccoli.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__roasted-broccoli.json
@@ -9,6 +9,7 @@
         "text": "Preheat oven to 450\u00b0. Toss broccoli and oil on a rimmed baking sheet; season with salt and pepper. Roast, tossing occasionally, until tender and browned, 25\u201335 minutes.\n\n\nEditor\u2019s note: This recipe was originally published in November 2015. Head this way for more of our best vegetable recipes \u2192"
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 large heads of broccoli, cut into large florets with some stalk attached",
       "5 Tbsp. olive oil",

--- a/tests/endpoint/snapshots/www.bonappetit.com__seafood-chowder.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__seafood-chowder.json
@@ -18,6 +18,7 @@
         "text": "Stir half-and-half mixture into chowder; return to medium heat. Bring to a simmer, stirring gently. Remove from heat; season with salt and more pepper. Ladle into bowls and serve with oyster crackers.\n\nEditor\u2019s note: This seafood chowder recipe was first printed in our May 2020 issue. Head this way for more of our best soup recipes \u2192"
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 Tbsp. unsalted butter, divided",
       "1 large onion, finely chopped",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__beef-cabbage-stir-fry.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__beef-cabbage-stir-fry.json
@@ -18,6 +18,7 @@
         "text": "Add the cabbage and carrots to the skillet and continue to stir and cook until the cabbage is slightly wilted (or fully wilted, if you prefer). Stir in the prepared sauce and the green onions. Top with a sprinkle of sesame seeds and a drizzle of sriracha, then serve."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 Tbsp soy sauce ($0.18)",
       "1 Tbsp toasted sesame oil ($0.33)",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__easy-pesto-chicken-and-vegetables.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__easy-pesto-chicken-and-vegetables.json
@@ -27,6 +27,7 @@
         "text": "Turn the heat off, add the pesto to the skillet, and stir until everything is coated. Give the vegetables a taste and add salt, pepper, or more pesto if desired. Top with a light sprinkle of Parmesan just before serving."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 red bell pepper ($1.50)",
       "1 zucchini ($0.60)",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__fried-cabbage-and-noodles.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__fried-cabbage-and-noodles.json
@@ -21,6 +21,7 @@
         "text": "Once the cabbage is tender, turn the heat off. Add the cooked and drained noodles, butter, and a generous amount of salt and pepper to the pot. Stir to combine and allow the residual heat to melt the butter. Taste the cabbage and noodles and add more salt and pepper to taste. Serve warm."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 Tbsp cooking oil ($0.08)",
       "1 yellow onion ($0.32)",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__one-pot-creamy-cajun-chicken-pasta.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__one-pot-creamy-cajun-chicken-pasta.json
@@ -24,6 +24,7 @@
         "text": "Add the cream cheese to the skillet in chunks, then stir until it has melted into the sauce. Top the pasta with sliced green onions and serve."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 tsp smoked paprika ($0.20)",
       "1 tsp oregano ($0.10)",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__unstuffed-bell-peppers.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__unstuffed-bell-peppers.json
@@ -30,6 +30,7 @@
         "text": "Pour the prepared tomato sauce over top, then sprinkled the shredded mozzarella over the sauce. Place the lid back on top and let the heat from the skillet melt the mozzarella. Once melted, sprinkle a little chopped parsley on top and serve."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 clove garlic ($0.08)",
       "1 yellow onion ($0.32)",

--- a/tests/endpoint/snapshots/www.cookingchanneltv.com__baked-potato-fries-reloaded-5470330.json
+++ b/tests/endpoint/snapshots/www.cookingchanneltv.com__baked-potato-fries-reloaded-5470330.json
@@ -24,6 +24,7 @@
         "text": "Slice the cold potatoes into half-inch-thick batons, leaving the skin attached. Boost the heat slightly before adding the first fries and cook 8 to 10 at a time until golden brown and delicious, 2-3 minutes. You'll have to adjust the heat to maintain the oil temperature, so keep an eye on it. Use a spider to fish the fries from the oil to a cooling rack set over paper towels. Sprinkle with additional salt while hot and devour."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "4 russet potatoes (about 8 ounces/227 grams each), scrubbed and rinsed",
       "2 teaspoons plus 2 quarts peanut oil",

--- a/tests/endpoint/snapshots/www.delish.com__creamy-tuscan-chicken-recipe.json
+++ b/tests/endpoint/snapshots/www.delish.com__creamy-tuscan-chicken-recipe.json
@@ -18,6 +18,7 @@
         "text": "Serve with lemon wedges."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 tbsp. extra-virgin olive oil",
       "4 boneless skinless chicken breasts",

--- a/tests/endpoint/snapshots/www.ethanchlebowski.com__grams-buns-the-greatest-bread-roll.json
+++ b/tests/endpoint/snapshots/www.ethanchlebowski.com__grams-buns-the-greatest-bread-roll.json
@@ -21,6 +21,7 @@
         "text": "Once your buns are golden brown and fluffy, take them out and lightly brush them in butter. Devour."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "160 ml warm milk",
       "6 g instant yeast",

--- a/tests/endpoint/snapshots/www.ethanchlebowski.com__kolaches-sweet-amp-savory.json
+++ b/tests/endpoint/snapshots/www.ethanchlebowski.com__kolaches-sweet-amp-savory.json
@@ -5,6 +5,7 @@
     "url": "https://www.ethanchlebowski.com/cooking-techniques-recipes/kolaches-sweet-amp-savory",
     "description": "The dough recipe below works for both savory and sweet kolaches. Use it to make just one kind or a mix of both. Ingredients Dough (makes about 9 kolaches worth) 400 g (3 1/4 cups) bread flour 200 g (~3/4 cup) milk, warmed 6 g (2 tsp) instant yeast 60 g (4 tbsp) unsalted butter, melte",
     "recipeInstructions": [],
+    "recipeInstructionSections": null,
     "recipeIngredient": [],
     "recipeCuisine": null,
     "recipeCategory": [],

--- a/tests/endpoint/snapshots/www.foodnetwork.com__baked-macaroni-and-cheese-recipe-1939524.json
+++ b/tests/endpoint/snapshots/www.foodnetwork.com__baked-macaroni-and-cheese-recipe-1939524.json
@@ -24,6 +24,7 @@
         "text": "Remember to save leftovers for fried Macaroni and Cheese."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1/2 pound elbow macaroni",
       "3 tablespoons butter",

--- a/tests/endpoint/snapshots/www.foodnetwork.com__instant-pancake-mix-recipe-1938544.json
+++ b/tests/endpoint/snapshots/www.foodnetwork.com__instant-pancake-mix-recipe-1938544.json
@@ -33,6 +33,7 @@
         "text": "Serve immediately or remove to a towel-lined baking sheet and cover with a towel. Hold in a warm place for 20 to 30 minutes."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "6 cups all-purpose flour",
       "1 1/2 teaspoons baking soda (check expiration date first)",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__brown-butter-oatmeal-chocolate-chip-cookies.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__brown-butter-oatmeal-chocolate-chip-cookies.json
@@ -9,6 +9,7 @@
         "text": "1. Preheat the oven to 350\u00b0 F. Line a baking sheet with parchment paper.2. Add the butter to a skillet set over medium heat. Cook until the butter begins to brown, about 3-4 minutes. Remove from the heat and transfer to a heatproof bowl. Let cool 5 minutes or so.3. To the brown butter, mix in the brown sugar, eggs, and vanilla, mixing until smooth. Add the flour, oats, baking soda, and salt. Gently fold in the chocolate. 4. Roll the dough into rounded tablespoon size balls and place 2 inches apart on the prepared baking sheet. Gently flatten the dough down. Bake 8 minutes. Remove from the oven, rotate and tap the baking sheet on the counter 1-2 times to flatten. Bake another 2-3 minutes or until the cookies are just beginning to set on the edges.5. Let the cookies cool on the baking sheet. They will continue to cook slightly as they sit on the baking sheet. Sprinkle with flaky salt (if desired). Eat warm (highly recommended) or let cool and store in an airtight container for up to 4 days.\u00a0"
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 sticks (1 cup) salted butter",
       "1 1/4 cup brown sugar",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__chicken-gyros-with-feta-tzatziki.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__chicken-gyros-with-feta-tzatziki.json
@@ -9,6 +9,7 @@
         "text": "1. In a bowl, combine the yogurt, olive oil, cubed chicken, lemon juice, garlic, shallots, paprika, oregano, chili flakes, and a large pinch each of salt and pepper. Let marinate for 15 minutes at room temperature or up to overnight in the refrigerator.2. Preheat the oven to 425\u00b0 F. Arrange the chicken on a baking sheet. Bake 15 minutes, toss and bake another 5-10 minutes, or until cooked through. Switch the oven to broil. Broil 1-2 minutes, until the chicken chars on the edges (watch carefully) 3. Meanwhile, make the Tzatziki. Combine the feta, 1/4 cup yogurt, garlic, and lemon juice in a blender and blend until creamy. Stir in 1/3 cup more yogurt, the cucumbers, and a pinch of salt and red pepper flakes.4. To assemble, stuff/spread each pita with tzatziki, then lettuce, and chicken. Add red onions and herbs. Drizzle over more tzatziki and if desired, harissa (recipe in notes)."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1/3 cup full-fat plain Greek yogurt",
       "1/4 cup extra virgin olive oil",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__chili-crisp-peanut-noodles.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__chili-crisp-peanut-noodles.json
@@ -9,6 +9,7 @@
         "text": "1. Bring a large pot of salted water to a boil. Cook the noodles according to package directions. Drain and add to a large bowl with the carrots and peppers.2. Meanwhile, in a food processor, combine the peanut butter, soy sauce, honey, curry paste, ginger, and 1/3 cup water. Pulse until combined and smooth. Pour the sauce over the warm noodles. Tossing well.3. Heat 1 tablespoon sesame oil in a skillet over medium heat. Add the Halloumi and cook until golden, about 5 minutes. Remove from the skillet.4. To the skillet, add 1/4 cup sesame oil, the garlic, and a pinch of chili flakes. Cook until the garlic crisps, about 5 minutes. Toss the Halloumi with 1/2 of the garlic oil, cilantro, basil, peanuts, and sesame seeds. Add the lime juice. 5. Divide the noodles between bowls and top with the halloumi, herbs, and additional chili garlic oil. Enjoy!"
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "8 ounces rice noodles or long cut pasta",
       "1/2 cup creamy peanut butter",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__creamy-parmesan-chicken-and-spinach-tortellini.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__creamy-parmesan-chicken-and-spinach-tortellini.json
@@ -9,6 +9,7 @@
         "text": "1. Season the chicken with salt and pepper. Place the flour and garlic powder in a shallow bowl and dredge the chicken through the flour mix, pressing to adhere.2. Heat 2 tablespoons olive oil in a large skillet set over medium-high heat. When the oil shimmers, add the chicken and sear on both sides until golden, about 5 minutes per side. Remove the chicken from the skillet.3. To the skillet, add 1 tablespoon olive oil, the shallots, garlic, thyme, and a pinch each of red pepper chili flakes, salt, and pepper. Cook 3-4 minutes, until fragrant. Add butter and spinach. Cook another 2-3 minutes, until the spinach is wilted.4. Pour in the wine and broth. Cook 8 minutes until reduced slightly, then add the tortellini and cook another 2 minutes. Pour in the cream and add the parmesan, stirring until melted and creamy. Add the chicken back to the skillet and simmer for 5 minutes or until warmed through and the sauce has thickened slightly. 5. Serve the chicken topped with the spinach cream sauce. Squeeze over a bit of lemon juice and a sprinkling of parmesan."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "4-6 chicken cutlets or 3 boneless chicken breasts sliced in half horizontally",
       "kosher salt and black pepper",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__green-chile-chicken.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__green-chile-chicken.json
@@ -9,6 +9,7 @@
         "text": "1. Preheat the oven to 425\u00b0 F. 2. Slice the chicken through the middle horizontally to within a 1/2 inch of the other side. Open the 2 sides and spread them out like an open book. Spread the cream cheese on 1 side of the chicken, then add the pepper jack and a few poblano pepper slices. Fold the other side of the chicken over the peppers/cheese, like a book, to enclose the filling. Place the chicken in the skillet or baking dish. Rub with olive oil. 3. In a small bowl combine the chili powder, paprika, garlic powder, salt and pepper. Rub the seasonings all over the chicken. 4. Sprinkle the remaining poblano peppers and onions around the chicken. Drizzle everything with olive oil, then pour over the salsa verde. Bake 20-25 minutes, until the chicken is cooked through. Serve with fresh cilantro and limes."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "4 boneless skinless chicken breasts",
       "2 ounces cream cheese, at room temperature",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__korean-beef-sesame-noodles.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__korean-beef-sesame-noodles.json
@@ -9,6 +9,7 @@
         "text": "1. To make the sauce. Combe all ingredients in a glass jar. Shake or whisk to combine. 2. Cook the rice noodles according to package directions.\u00a0Drain and rinse under cold water. 3. Heat 1 tablespoon oil in a large skillet over high heat. Add the vegetables and cook until wilted, 2-3 minutes. Stir in 2 tablespoons of the sauce. Cook until the sauce coats the veggies. Remove from the pan. 4. In the same skillet, add 1 tablespoon oil. Then add the shallots and cook 2 minutes, until deeply softened. Add the beef and cook, undistributed, until seared, 2 minutes. Toss the meat, then pour in the sauce. Simmer 1 minute, then stir in the noodles and vegetables. Cook 2-3 minutes, until the sauce coats the noodles. 5. Remove from the heat and stir in the basil and sesame seeds. Serve topped with fresh basil."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "4 cloves garlic chopped",
       "1 tablespoon chopped fresh ginger",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__one-pot-hamburger-helper.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__one-pot-hamburger-helper.json
@@ -9,6 +9,7 @@
         "text": "1. In a large pot set over medium hight heat,\u00a0add the olive oil, onion and beef. Season with salt and pepper. Cook until brown all over, breaking up the meat as you go, about 10 minutes. Stir in the chili powder, paprika, and garlic powder, cook another minute.2. Add the pasta and zucchini and toss to coat, then pour in the broth and milk. Add the ketchup and stir to combine. Season with salt. 3. Bring to a gentle boil over medium high heat. Simmer 5-8 minutes until the pasta is al dente, stirring often. 4. Stir in the cheese and cook another few minutes until very creamy. 5. Divide the pasta among bowls and top with fresh parsley. Enjoy!"
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "2 tablespoons extra virgin olive oil",
       "1 pound lean ground beef",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__roasted-red-pepper-chicken-pasta.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__roasted-red-pepper-chicken-pasta.json
@@ -9,6 +9,7 @@
         "text": "1. To make the red pepper sauce. In a blender or food processor, combine the red peppers, walnuts, tomatoes, garlic, parsley, olive oil, vinegar, honey, 1 teaspoon paprika, cayenne, and a generous pinch of salt. Blend until smooth, about 1 minute. 2. Set a large pot or skillet with sides over medium-high heat. Add the chicken, Italian seasoning, 1 teaspoon paprika, and a pinch each of red pepper flakes, salt, and pepper. Cook until golden brown, 5 minutes. Add 1/4 cup manchego, cook another minute, then remove the chicken from the pot.3. To the same pot, pour in 3 1/2 cups water. Bring to a boil, add the pasta, and cook, stirring often, until the pasta is al dente, 8 minutes. Do not drain the pasta water. If needed, add additional water to help the pasta cook. 4. Stir in the roasted red pepper sauce (you may not need it all), manchego, and basil. Toss until very creamy and heated through. Slide in the chicken and any juices left on the plate.5. Serve the pasta topped with fresh manchego and arugula. Enjoy!"
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 jar (12-ounce) roasted red peppers (drained)",
       "1/2 cup toasted walnuts",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__stove-top-mac-and-cheese.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__stove-top-mac-and-cheese.json
@@ -9,6 +9,7 @@
         "text": "1. In a large pot, bring 4 cups of water to a boil over high heat. Add 1 1/2 teaspoons salt, the pasta, and broccoli. Cook, stirring occasionally, for 8 minutes. Do not drain the water. Stir in the milk, cream cheese, and mustard, and cook until the cream cheese has melted and the pasta is al dente, about 4-5 minutes more. Stir in the zucchini.2.\u00a0Add the cheeses, garlic powder, onion powder, paprika, cayenne, and butter (if using), and stir until melted and creamy. Remove from the heat. Season with salt and pepper. If the sauce feels thick, add \u00bc cup milk or water to thin.3. Divide the mac and cheese between bowls. Top with black pepper."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "1 pound short-cut pasta",
       "1 head broccoli, chopped",

--- a/tests/endpoint/snapshots/www.hellofresh.com__uk-balsamic-streak-with-red-cabb-5841a8ad9df18165854cdd72.json
+++ b/tests/endpoint/snapshots/www.hellofresh.com__uk-balsamic-streak-with-red-cabb-5841a8ad9df18165854cdd72.json
@@ -24,6 +24,7 @@
         "text": "Thinly slice steak against the grain. Divide steak, potatoes, and cabbage between plates. Drizzle glaze over steak and serve."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "12 ounce Sirloin Steak",
       "2 tablespoon Balsamic Vinegar",

--- a/tests/endpoint/snapshots/www.joshuaweissman.com__best-mac-and-cheese-recipe.json
+++ b/tests/endpoint/snapshots/www.joshuaweissman.com__best-mac-and-cheese-recipe.json
@@ -5,6 +5,7 @@
     "url": "https://www.joshuaweissman.com/best-mac-and-cheese-recipe",
     "description": "Homemade mac and cheese is not only one of the easiest things to make, but it's also one of the most satisfying. Nothing feels better than having such a level of control in your own life that you make macaroni and cheese from scratch.",
     "recipeInstructions": [],
+    "recipeInstructionSections": null,
     "recipeIngredient": [],
     "recipeCuisine": null,
     "recipeCategory": [

--- a/tests/endpoint/snapshots/www.recipetineats.com__greek-chicken-gyros-with-tzatziki.json
+++ b/tests/endpoint/snapshots/www.recipetineats.com__greek-chicken-gyros-with-tzatziki.json
@@ -39,6 +39,66 @@
         "text": "I prefer to lay everything out on a table and let everyone help themselves."
       }
     ],
+    "recipeInstructionSections": [
+      {
+        "name": null,
+        "steps": [
+          {
+            "text": "Place the Marinade ingredients in a ziplock bag and massage to mix. Add the chicken into the ziplock bag and massage to cover all the chicken in the Marinade. Marinate for at least 2 hours, preferably 3 hours, ideally 12 hours and no longer than 24 hours."
+          }
+        ]
+      },
+      {
+        "name": "Make the Tzatziki",
+        "steps": [
+          {
+            "text": "Cut the cucumber in half lengthwise. Use a teaspoon to scrape the watery seeds out. Coarsely grate the cucumber using a box grater. Then wrap in paper towels or a tea towel and squeeze to remove excess liquid."
+          },
+          {
+            "text": "Place cucumber in a bowl. Add remaining ingredients then mix to combine. Set aside for at least 20 minutes for the flavours to meld."
+          }
+        ]
+      },
+      {
+        "name": "Salad",
+        "steps": [
+          {
+            "text": "Combine ingredients in a bowl."
+          }
+        ]
+      },
+      {
+        "name": "Cook Chicken",
+        "steps": [
+          {
+            "text": "Brush the outdoor grill with oil, then preheat on medium high. Or heat 1 tbsp of oil in a fry pan over medium high heat."
+          },
+          {
+            "text": "Remove chicken from Marinade. Cook the chicken for 2 to 3 minutes on each side, until golden brown and cooked through (cooking time depends on size of chicken)."
+          },
+          {
+            "text": "Remove the chicken from the grill / fry pan onto a plate. Cover loosely with foil and allow to rest for 5 minutes before serving."
+          }
+        ]
+      },
+      {
+        "name": "Assemble Gyros",
+        "steps": [
+          {
+            "text": "If your chicken thighs are large, you may need to cut them. Mine were small."
+          },
+          {
+            "text": "Get a pita bread or flatbread (preferably warmed) and place it on a piece of parchment (baking) paper (or you could use foil). Place some Salad down the middle of the bread, then top with chicken and Tzatziki."
+          },
+          {
+            "text": "Roll the wrap up, enclosing it with the parchment paper. Twist the end with the excess parchment paper to secure it and cut if desired."
+          },
+          {
+            "text": "I prefer to lay everything out on a table and let everyone help themselves."
+          }
+        ]
+      }
+    ],
     "recipeIngredient": [
       "2 lb / 1 kg chicken thigh fillets (, boneless skinless)",
       "3 large garlic cloves (, minced (~ 3 tsp))",
@@ -111,7 +171,7 @@
       "unit": "pound",
       "comment": "(, boneless skinless)",
       "other": "",
-      "confidence": 0.999818
+      "confidence": 0.999847
     },
     {
       "input": "3 large garlic cloves (, minced (~ 3 tsp))",

--- a/tests/endpoint/snapshots/www.recipetineats.com__naan-recipe.json
+++ b/tests/endpoint/snapshots/www.recipetineats.com__naan-recipe.json
@@ -51,6 +51,63 @@
         "text": "Heat a well-seasoned cast iron skillet preheated over high heat, but not until the skillet is smoking. Cook naan for around 1 1/2 minutes on the first side until golden \u2013 it will puff up! Turn and cook the other side for around 45 seconds."
       }
     ],
+    "recipeInstructionSections": [
+      {
+        "name": null,
+        "steps": [
+          {
+            "text": "Bloom yeast: Mix yeast with warm water and sugar in a small bowl. Cover with cling wrap, leave for 10 minutes until foamy."
+          },
+          {
+            "text": "Egg and milk: Whisk milk and egg together."
+          },
+          {
+            "text": "Flour: Sift flour and salt into a separate bowl."
+          },
+          {
+            "text": "Add wet ingredients: Make a well in the flour, add yeast mixture, and butter and egg mixture. Mix together with a spatula. Once the flour is mostly incorporated, switch to your hands and bring it together into a ball. No kneading is required."
+          },
+          {
+            "text": "Proof 1: Cover the bowl with cling-wrap, then leave in a warm place for 1 - 1.5 hrs until it doubles in size. (Note 7)"
+          },
+          {
+            "text": "Cut into 6 pieces: Place the dough on a lightly floured surface. Cut into 6 equal pieces, then shape into balls into spheres with a smooth surface by stretching the surface and tucking it under (see video)."
+          },
+          {
+            "text": "Proof 2: Place balls on a lightly-floured tray or plate. Sprinkle lightly with flour, cover loosely with a lightweight tea towel. Put in a warm place to rise for 15 minutes until it increases in size by about 50%."
+          },
+          {
+            "text": "Roll out: Place a round on a lightly-floured work surface, flatten with your hand. Roll out into 3 - 4mm / 0.12 - 0.16\" thick rounds (about 16cm / 6.5\" wide)."
+          },
+          {
+            "text": "Heat skillet: Rub a cast iron skillet with a very light coat of oil using 1/2 tsp oil on a paper towl (unless already well seasoned). Set over high heat until you see wisps of smoke. (Note 8 for other pans)"
+          },
+          {
+            "text": "Cook naan: Place a naan dough in the skillet and cook for 1 to 1 1/2 minutes until the underside is deep golden / slightly charred \u2013 the surface should get bubbly. Flip then cook the other side for 1 minute until the bubbles become deep golden brown."
+          },
+          {
+            "text": "Cook remaining naan: Remove, set aside, and repeat with remaining naan, taking care to regulate the heat of the skillet so it doesn't get too hot."
+          },
+          {
+            "text": "Finishing: Brush freshly cooked naan with melted butter or ghee (or garlic butter, Note 5). Sprinkle with nigella seeds and coriander. Serve hot!"
+          }
+        ]
+      },
+      {
+        "name": "Cheese Naan:",
+        "steps": [
+          {
+            "text": "Roll out a naan per above directions. Brush with plain butter or garlic butter. (Note 5) Place a mound of cheese in the middle - about 1/4 cup, lightly-packed. Bundle it up, money bag-style, then twist to seal."
+          },
+          {
+            "text": "Turn upside down so the smooth side is up. Roll out to 6-7mm / 1/4\" thick rounds."
+          },
+          {
+            "text": "Heat a well-seasoned cast iron skillet preheated over high heat, but not until the skillet is smoking. Cook naan for around 1 1/2 minutes on the first side until golden \u2013 it will puff up! Turn and cook the other side for around 45 seconds."
+          }
+        ]
+      }
+    ],
     "recipeIngredient": [
       "1 tsp instant / rapid rise yeast ((Note 1))",
       "1/2 cup warm tap water ((~40\u00b0C/105\u00b0F in temperature))",
@@ -173,7 +230,7 @@
       "unit": "gram",
       "comment": ", melted",
       "other": "",
-      "confidence": 0.999812
+      "confidence": 0.999423
     },
     {
       "input": "30g / 2 tbsp tbsp ghee or butter (, melted (Note 4))",
@@ -182,7 +239,7 @@
       "unit": "gram",
       "comment": ", melted",
       "other": "",
-      "confidence": 0.999829
+      "confidence": 0.999423
     },
     {
       "input": "1 small garlic clove (, for Garlic Butter option (Note 5))",

--- a/tests/endpoint/snapshots/www.seriouseats.com__copycat-chicken-nuggets-with-sweet-n-sour-sauce.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__copycat-chicken-nuggets-with-sweet-n-sour-sauce.json
@@ -24,6 +24,7 @@
         "text": "Bring oil to 375\u00b0F (190\u00b0C). Carefully return all nuggets to oil and cook, flipping occasionally, until deep golden brown and very crispy, about 4 minutes. Return nuggets to rack and let stand for 2 minutes. Serve with sauce."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "For the Nuggets:",
       "1 pound (450g) boneless, skinless chicken thighs, cut into 1-inch pieces",

--- a/tests/endpoint/snapshots/www.seriouseats.com__easy-no-knead-focaccia.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__easy-no-knead-focaccia.json
@@ -27,6 +27,7 @@
         "text": "Transfer skillet to oven, positioning it on top of baking stone, and bake, rotating pan halfway through baking, until top is golden brown and bottom is golden brown and crisp when you lift it with a thin spatula, 25 to 30 minutes. Let focaccia cool in skillet for 5 minutes, then use a thin spatula to transfer focaccia to wire rack set inside a rimmed baking sheet. Spoon or brush any olive oil left in the skillet over the focaccia, and let cool for at least 10 minutes before slicing. Serve warm or at room temperature."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "500 grams bread or all-purpose flour (17.5 ounces; about 3 1/4 cups), see note",
       "10 grams Diamond Crystal kosher salt (0.4 ounce; 2 1/2 teaspoons); for table salt, use about half as much by volume or the same weight",

--- a/tests/endpoint/snapshots/www.seriouseats.com__five-minute-grilled-chicken-cutlet-rosemary-garlic-lemon-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__five-minute-grilled-chicken-cutlet-rosemary-garlic-lemon-recipe.json
@@ -15,6 +15,7 @@
         "text": "Place chicken directly over the hot side of the grill, cover, and cook, rotating the pieces occasionally (but not flipping them), until the chicken is almost completely cooked through and only a few pink spots remain on the top side, about 4 minutes. Flip chicken and cook on second side until just done, about 30 seconds. Transfer to a serving platter. Re-whisk reserved marinade and pour it over the chicken. Serve immediately."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "3 medium cloves garlic, minced (about 1 tablespoon)",
       "3 tablespoons minced fresh rosemary",

--- a/tests/endpoint/snapshots/www.seriouseats.com__ingredient-stovetop-mac-and-cheese-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__ingredient-stovetop-mac-and-cheese-recipe.json
@@ -12,6 +12,7 @@
         "text": "Immediately add evaporated milk and bring to a boil. Add cheese. Reduce heat to low and cook, stirring continuously, until cheese is melted and liquid has reduced to a creamy sauce, about 2 minutes longer. Season to taste with more salt and serve immediately."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "6 ounces (170g) elbow macaroni",
       "Salt",

--- a/tests/endpoint/snapshots/www.seriouseats.com__salmon-burgers-remoulade-fennel-slaw-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__salmon-burgers-remoulade-fennel-slaw-recipe.json
@@ -27,6 +27,7 @@
         "text": "Transfer patties to a paper towel-lined tray and sprinkle lightly with kosher salt. Smear an even layer of r\u00e9moulade on the top and bottom halves of each bun. Set a salmon patty on top of each bottom bun. Season slaw with salt and pepper, then mound some on top of each patty. Close sandwiches and serve right away."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "For the Salmon Patties:",
       "1 1/2 pounds boneless, skinless salmon (680g), very finely chopped by hand",

--- a/tests/endpoint/snapshots/www.seriouseats.com__spicy-spring-sicilian-pizza-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__spicy-spring-sicilian-pizza-recipe.json
@@ -30,6 +30,7 @@
         "text": "Remove pizza from oven. Sprinkle with remaining half of Romano cheese, use a pizza wheel to cut it into slices, and serve immediately."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "For the Dough (see note):",
       "500g bread flour (17.5 ounces; about 3 1/2 cups)",

--- a/tests/endpoint/snapshots/www.seriouseats.com__the-best-roast-potatoes-ever-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__the-best-roast-potatoes-ever-recipe.json
@@ -21,6 +21,7 @@
         "text": "Transfer potatoes to a large bowl and add garlic/rosemary mixture and minced parsley. Toss to coat and season with more salt and pepper to taste. Serve immediately."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "Kosher salt",
       "1/2 teaspoon (4g) baking soda",

--- a/tests/endpoint/snapshots/www.tasteofhome.com__dutch-oven-bread.json
+++ b/tests/endpoint/snapshots/www.tasteofhome.com__dutch-oven-bread.json
@@ -15,6 +15,7 @@
         "text": "Using a sharp knife or a bread lame, make a slash across the top of the loaf. It should be 1/4-inch deep. Using the parchment, immediately lower the dough into the heated Dutch oven. Cover and bake the bread for 30 minutes. Uncover and bake until the bread is deep golden brown and sounds hollow when tapped, 15 to 20 minutes longer. Partially cover the loaf if it browns too much. Remove the loaf from the pan and cool completely on a wire rack."
       }
     ],
+    "recipeInstructionSections": null,
     "recipeIngredient": [
       "3 to 3-1/2 cups (125 grams per cup) all-purpose flour",
       "1 teaspoon active dry yeast",


### PR DESCRIPTION
## Summary

- Add `InstructionStep` and `InstructionSection` models to preserve schema.org HowToSection structure
- Add `clean_instruction_sections()` function to extract sectioned instructions
- API now returns both flat `recipeInstructions` (backward compatible) and sectioned `recipeInstructionSections` when source has HowToSection data

## Changes

### New Models (`pkg/services/recipes/recipe.py`)
```python
class InstructionStep(BaseModel):
    text: str

class InstructionSection(BaseModel):
    name: str | None = None
    steps: list[InstructionStep]
```

### Response Format
When a recipe has HowToSection structures:
```json
{
  "recipeInstructions": [{"text": "Step 1..."}, {"text": "Step 2..."}],
  "recipeInstructionSections": [
    {"name": null, "steps": [{"text": "Step 1..."}, {"text": "Step 2..."}]},
    {"name": "Cheese Naan:", "steps": [{"text": "Cheese step..."}]}
  ]
}
```

### Behavior
- `recipeInstructionSections` only present when source has HowToSection
- Handles mixed arrays (HowToStep + HowToSection in same array)
- Ungrouped steps get `name: null` sections
- All text is cleaned (HTML stripped, whitespace normalized)

## Test plan
- [x] Added 8 unit tests for `clean_instruction_sections()`
- [x] Updated 54 endpoint snapshots
- [x] All 163 tests pass
- [x] Verified with RecipeTinEats recipes that use HowToSection