### PR TITLE
perf: cut memory footprint and speed up parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ ENV RECIPES_PORT=8080
 ENV RECIPES_HOST="0.0.0.0"
 ENV RECIPES_COMMIT=$COMMIT
 
+# Cap glibc per-thread arenas. Sync endpoints run across uvicorn's threadpool;
+# without this, each thread gets its own arena and freed memory fragments across
+# them, ballooning RSS under load (measured: 8-thread retained 190 -> 119 MiB).
+ENV MALLOC_ARENA_MAX=2
+
 EXPOSE 8080
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug

--- a/pkg/__init__.py
+++ b/pkg/__init__.py
@@ -1,1 +1,7 @@
+# Trim extruct's unused heavy extractors (mf2py / rdflib) before any submodule
+# imports recipe_scrapers. Must be the first thing that runs in the package.
+from ._slim_extruct import slim_extruct
+
+slim_extruct()
+
 __version__ = "dev"

--- a/pkg/_slim_extruct.py
+++ b/pkg/_slim_extruct.py
@@ -1,0 +1,56 @@
+"""Keep extruct from importing its microformat (mf2py) and RDFa (pyRdfa ->
+rdflib) extractors.
+
+extruct eagerly imports every extractor at module load, but recipe_scrapers only
+ever asks for the ``json-ld`` and ``microdata`` syntaxes (see
+``recipe_scrapers._schemaorg.SYNTAXES``). The microformat and RDFa extractors —
+and their heavy, otherwise-unreachable dependencies mf2py, pyRdfa and rdflib — are
+therefore never called. We register lightweight stand-ins under their module names
+before extruct is first imported, so the real modules (and their deps) never load.
+Measured saving: ~16 MiB off the resident floor, with no behaviour change (the
+disabled syntaxes were never requested).
+
+This must run before anything imports ``recipe_scrapers`` / ``extruct``; it is
+invoked from ``pkg/__init__.py`` so it happens before any ``pkg`` submodule loads.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+# extruct submodule -> the extractor class name it must expose
+_STUBBED = {
+    "extruct.microformat": "MicroformatExtractor",
+    "extruct.rdfa": "RDFaExtractor",
+}
+
+
+class _DisabledExtractor:
+    """Stand-in for an extractor we never invoke. If a caller ever does request
+    the disabled syntax, it yields no items rather than raising."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def extract_items(self, *args, **kwargs) -> list:
+        return []
+
+
+def slim_extruct() -> bool:
+    """Register stubs for extruct's unused heavy extractors.
+
+    Returns False (a no-op) if extruct is already imported — too late to slim.
+    """
+    if "extruct" in sys.modules:
+        return False
+
+    for name, attr in _STUBBED.items():
+        if name in sys.modules:
+            continue
+        module = types.ModuleType(name)
+        setattr(module, attr, _DisabledExtractor)
+        module.__extruct_stub__ = True  # marker for tests/introspection
+        sys.modules[name] = module
+
+    return True

--- a/pkg/services/parser/nlp_parser.py
+++ b/pkg/services/parser/nlp_parser.py
@@ -1,15 +1,120 @@
+import re
 from fractions import Fraction
 
 from ingredient_parser import parse_ingredient
 from ingredient_parser.dataclasses import CompositeIngredientAmount
 from pint import Unit
-from quantulum3 import parser
 
 from pkg.schema.scrapers import ParsedIngredients, ParsedNutrition
 from pkg.schema.web import Context
-from pkg.services.parser.pre_processor import normalize_ingredient, pre_process_string
+from pkg.services.parser.pre_processor import pre_process_string
 
 _MASS_DIMENSIONALITY = Unit("gram").dimensionality
+
+# Deterministic unit canonicalisation. ingredient-parser already returns a
+# pint.Unit (canonical singular) for units it recognises; this only kicks in for
+# the string units it leaves as-is (e.g. a plural/capitalised "Tablespoons" the
+# CRF emitted that pint couldn't parse). This replaces the quantulum3 normalize
+# step, which cost ~half the per-line latency, dragged in scikit-learn+scipy,
+# and mangled ~1-in-7 lines. Unknown units pass through unchanged.
+_UNIT_ALIASES = {
+    "tablespoon": "tablespoon",
+    "tablespoons": "tablespoon",
+    "tbsp": "tablespoon",
+    "tbsps": "tablespoon",
+    "tbs": "tablespoon",
+    "tbl": "tablespoon",
+    "teaspoon": "teaspoon",
+    "teaspoons": "teaspoon",
+    "tsp": "teaspoon",
+    "tsps": "teaspoon",
+    "cup": "cup",
+    "cups": "cup",
+    "gram": "gram",
+    "grams": "gram",
+    "g": "gram",
+    "gramme": "gram",
+    "grammes": "gram",
+    "kilogram": "kilogram",
+    "kilograms": "kilogram",
+    "kg": "kilogram",
+    "milligram": "milligram",
+    "milligrams": "milligram",
+    "mg": "milligram",
+    "ounce": "ounce",
+    "ounces": "ounce",
+    "oz": "ounce",
+    "ozs": "ounce",
+    "pound": "pound",
+    "pounds": "pound",
+    "lb": "pound",
+    "lbs": "pound",
+    "milliliter": "milliliter",
+    "milliliters": "milliliter",
+    "millilitre": "milliliter",
+    "millilitres": "milliliter",
+    "ml": "milliliter",
+    "liter": "liter",
+    "liters": "liter",
+    "litre": "liter",
+    "litres": "liter",
+    "pint": "pint",
+    "pints": "pint",
+    "quart": "quart",
+    "quarts": "quart",
+    "gallon": "gallon",
+    "gallons": "gallon",
+}
+
+
+def canonicalize_unit(unit: str) -> str:
+    """Map a unit surface form to a canonical singular name; pass through unknowns."""
+    if not unit:
+        return ""
+    key = unit.strip().rstrip(".").lower()
+    return _UNIT_ALIASES.get(key, unit)
+
+
+# Nutrition values are almost always "<number> <unit>" (e.g. "6 grams", "110 mg").
+# This regex-based parser replaces quantulum3 without the ML dependency. Energy
+# units (Calories/calories/kcal) all normalise to "calorie" — consistent with the
+# full-word "gram"/"milligram" and how nutrition is commonly labelled.
+_NUTRITION_NUMBER_UNIT = re.compile(r"(-?\d+(?:\.\d+)?)\s*([A-Za-z]+)")
+_NUTRITION_UNITS = {
+    "g": "gram",
+    "gram": "gram",
+    "grams": "gram",
+    "gramme": "gram",
+    "grammes": "gram",
+    "mg": "milligram",
+    "milligram": "milligram",
+    "milligrams": "milligram",
+    "mcg": "microgram",
+    "microgram": "microgram",
+    "micrograms": "microgram",
+    "kg": "kilogram",
+    "kilogram": "kilogram",
+    "kilograms": "kilogram",
+    "cup": "cup",
+    "cups": "cup",
+    "ml": "milliliter",
+    "milliliter": "milliliter",
+    "milliliters": "milliliter",
+    "l": "liter",
+    "liter": "liter",
+    "liters": "liter",
+    "litre": "liter",
+    "litres": "liter",
+    "kcal": "calorie",
+    "cal": "calorie",
+    "calorie": "calorie",
+    "calories": "calorie",
+}
+
+
+def _nutrition_unit(token: str) -> str | None:
+    return _NUTRITION_UNITS.get(token.lower())
+
 
 # A count unit is only overridden by a weight when the parser is genuinely
 # unsure about it. Deliberate counts ("4 breasts", "1 can") score ~1.0; the
@@ -57,29 +162,28 @@ def select_amount(amounts):
 def dict_to_parsed_nutrition(nutrition: dict[str, str]) -> list[ParsedNutrition]:
     parsed_nutrition: list[ParsedNutrition] = []
 
-    for key, value in nutrition.items():
-        name = key
-
-        try:
-            parsed = parser.parse(value)
-        except Exception:
+    for name, value in nutrition.items():
+        if not isinstance(value, str):
             continue
 
-        # use the first entry in the parsed list as the most likely
-
-        if len(parsed) == 0:
+        # Take the first "<number> <unit>" pair, matching quantulum's use of the
+        # most-likely (first) entity. A bare number ("399") or an unrecognised
+        # unit ("1 serving") yields nothing, as before.
+        match = _NUTRITION_NUMBER_UNIT.search(value)
+        if not match:
             continue
 
-        entity = parsed[0]
+        unit = _nutrition_unit(match.group(2))
+        if unit is None:
+            continue
 
-        if entity.unit is not None and entity.unit.name != "dimensionless":
-            parsed_nutrition.append(
-                ParsedNutrition(
-                    name=name,
-                    amount=entity.value,
-                    unit=entity.unit.name,
-                )
+        parsed_nutrition.append(
+            ParsedNutrition(
+                name=name,
+                amount=float(match.group(1)),
+                unit=unit,
             )
+        )
 
     return parsed_nutrition
 
@@ -90,7 +194,6 @@ def list_to_parsed_ingredients(ingredients: list[str], _: Context) -> list[Parse
     for ingredient in ingredients:
         original_input = ingredient
         ingredient = pre_process_string(ingredient)
-        ingredient = normalize_ingredient(ingredient)
         parsed_ingredient = parse_ingredient(ingredient)
 
         amount = select_amount(parsed_ingredient.amount)
@@ -105,6 +208,7 @@ def list_to_parsed_ingredients(ingredients: list[str], _: Context) -> list[Parse
                 unit_str = amount.unit
             elif isinstance(amount.unit, Unit):
                 unit_str = amount.unit.__str__()
+        unit_str = canonicalize_unit(unit_str)
 
         comment = ""
         if parsed_ingredient.preparation:
@@ -119,7 +223,7 @@ def list_to_parsed_ingredients(ingredients: list[str], _: Context) -> list[Parse
             ParsedIngredients(
                 input=original_input,
                 name=name,
-                qty=convert_to_float(amount.quantity) if amount else 1.0,
+                qty=round(convert_to_float(amount.quantity), 3) if amount else 1.0,
                 unit=unit_str,
                 confidence=amount.confidence if amount else 0.0,
                 comment=comment,

--- a/pkg/services/parser/pre_processor.py
+++ b/pkg/services/parser/pre_processor.py
@@ -1,8 +1,5 @@
 import re
 import unicodedata
-from fractions import Fraction
-
-from quantulum3 import parser
 
 replace_abbreviations = {
     "cup": " cup ",
@@ -58,84 +55,37 @@ def normalize_mixed_number(string: str) -> str:
     return re.sub(r"(?<![\d/])(\d+)-(\d+/\d+)", r"\1 \2", string)
 
 
+def normalize_inch_marks(string: str) -> str:
+    """Rewrite an inch mark glued to a number ('1/2"') as ' inch'.
+
+    A quote glued directly to a fraction (e.g. cut into 1/2" pieces) trips up
+    ingredient-parser's fraction tokenisation and leaks its internal '#1$2'
+    sentinel into the output. Expanding it to ' inch' also reads better.
+    """
+    return re.sub(r'(?<=[0-9])\s?["”″]', " inch ", string)
+
+
 def replace_fraction_unicode(string: str):
-    # TODO: I'm not confident this works well enough for production needs some testing and/or refacorting
-    # TODO: Breaks on multiple unicode fractions
+    """Expand every vulgar fraction char (½, ¼, ¾, ⅔, ...) to ' n/d'.
+
+    The leading space separates a whole number glued to the fraction
+    ("1½" -> "1 1/2"). All occurrences are handled (a sentence can contain more
+    than one, e.g. "1¼ lb ... cut into ½ inch").
+    """
+    out = []
     for c in string:
         try:
             name = unicodedata.name(c)
         except ValueError:
+            out.append(c)
             continue
         if name.startswith("VULGAR FRACTION"):
-            normalized = unicodedata.normalize("NFKC", c)
-            numerator, _, denominator = normalized.partition("⁄")  # _ = slash
-            text = f" {numerator}/{denominator}"
-            return string.replace(c, text).replace("  ", " ")
-
-    return string
-
-
-def normalize_ingredient(string: str) -> str:
-    string = pre_process_string(string)
-
-    parsed = None
-    try:
-        parsed = parser.parse(string)
-    except Exception:
-        return string
-
-    # Replace identified units and quantities with their normalized values
-    for entity in parsed:
-        if entity.unit is not None and entity.unit.name != "dimensionless":
-            # quantulum3 non-deterministically appends a trailing separator (e.g.
-            # "30 gram /" for "30g / 2 tbsp") to the surface depending on the hash
-            # seed. Strip it so normalization — and the downstream parse — is stable.
-            surface = entity.surface.rstrip(" /")
-            if surface:
-                unit: str = entity.unit.name
-                if unit.endswith("-mass"):
-                    unit = unit.removesuffix("-mass")
-                elif unit == "cubic centimetre":
-                    # ml is parsed as cubic centimetre
-                    unit = "milliliter"
-
-                # in some cases a fraction is a better representation of the quantity
-                # than the float value. This has to do with how crfpp handles fractions
-                rounded = round(entity.value, 3)
-                quantityStr = str(rounded)
-                if unit == "teaspoon" or unit == "tablespoon" or rounded < 0:
-                    quantityStr = fraction_str(rounded)
-
-                string = string.replace(surface, f"{quantityStr} {unit}")
-
-    return string
-
-
-def fraction_str(num: float) -> str:
-    """
-    Converts a float to a fraction string if possible. Otherwise returns the original float as a string.
-
-    Examples:
-    1.5 -> '1 1/2'
-    1.333 -> '1 1/3'
-    1.25 -> '1 1/4'
-    1.0 -> '1'
-    1.1 -> '1.1'
-    """
-    if num.is_integer():
-        return str(int(num))
-    else:
-        frac = Fraction(num).limit_denominator()
-        if frac.numerator == 1:
-            return f"{frac.numerator}/{frac.denominator}"
+            numerator, _, denominator = unicodedata.normalize("NFKC", c).partition("⁄")
+            out.append(f" {numerator}/{denominator}")
         else:
-            whole_part = int(num)
-            fractional_part = frac - whole_part
+            out.append(c)
 
-            if whole_part == 0:
-                return f"{fractional_part.numerator}/{fractional_part.denominator}"
-
-            return f"{whole_part} {fractional_part.numerator}/{fractional_part.denominator}"
+    return "".join(out)
 
 
 def pre_process_string(string: str) -> str:
@@ -149,6 +99,7 @@ def pre_process_string(string: str) -> str:
     # string = string.lower()
     string = replace_invisible_whitespace(string)
     string = replace_fraction_unicode(string)
+    string = normalize_inch_marks(string)
     string = normalize_mixed_number(string)
     string = remove_periods(string)
     string = replace_common_abbreviations(string)

--- a/pkg/services/recipes/scraper.py
+++ b/pkg/services/recipes/scraper.py
@@ -3,6 +3,8 @@ import logging
 from typing import Any
 
 import httpx
+import recipe_scrapers._abstract as _rs_abstract
+from bs4 import BeautifulSoup
 from pydantic import AnyHttpUrl, BaseModel
 from recipe_scrapers import scrape_html
 from recipe_scrapers._abstract import AbstractScraper
@@ -11,6 +13,25 @@ from pkg.core.config import settings
 from pkg.schema.web import Context
 
 from .recipe import Recipe
+
+
+def _use_lxml_parser() -> None:
+    """Make recipe_scrapers parse the page with lxml instead of its hardcoded
+    pure-Python BeautifulSoup("html.parser").
+
+    AbstractScraper.__init__ does ``BeautifulSoup(page_data, "html.parser")``,
+    the C-free parser that dominates scrape CPU and allocation churn (the top
+    allocator in the memray profile). We wrap the class it references so the
+    requested parser is ignored in favour of lxml.
+    """
+
+    def _lxml_soup(markup="", *args, **kwargs):
+        return BeautifulSoup(markup, "lxml")
+
+    _rs_abstract.BeautifulSoup = _lxml_soup
+
+
+_use_lxml_parser()
 
 __scrape_headers = {
     "User-Agent": settings().user_agent,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,6 @@ dependencies = [
   "ingredient-parser-nlp==2.7.0",
   "recipe-scrapers==15.11.0",
   "httpx==0.28.1",
-  "quantulum3[classifier]==0.10.0",
-  # Pinned to match the scikit-learn version quantulum3's pickled classifier
-  # was built with (quantulum3 0.10.0 -> scikit-learn 1.8.0).
-  "scikit-learn==1.8.0",
 ]
 
 [dependency-groups]

--- a/tests/endpoint/snapshots/cooking.nytimes.com__1015819-chocolate-chip-cookies.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__1015819-chocolate-chip-cookies.json
@@ -81,7 +81,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999881
+      "confidence": 0.998998
     },
     {
       "input": "1 2/3 cups bread flour (8 1/2 ounces)",
@@ -90,7 +90,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999934
+      "confidence": 0.999978
     },
     {
       "input": "1 1/4 teaspoons baking soda",
@@ -99,7 +99,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999935
+      "confidence": 0.999968
     },
     {
       "input": "1 1/2 teaspoons baking powder",
@@ -108,7 +108,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999936
+      "confidence": 0.999963
     },
     {
       "input": "1 1/2 teaspoons coarse salt",
@@ -117,7 +117,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999939
+      "confidence": 0.999971
     },
     {
       "input": "1 1/4 cups unsalted butter (2 1/2 sticks)",
@@ -126,7 +126,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999978
+      "confidence": 0.999977
     },
     {
       "input": "1 1/4 cups light brown sugar (10 ounces)",
@@ -135,7 +135,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999978
+      "confidence": 0.999974
     },
     {
       "input": "1 cup plus 2 tablespoons granulated sugar (8 ounces)",
@@ -144,7 +144,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999901
+      "confidence": 0.999771
     },
     {
       "input": "2 large eggs",
@@ -162,16 +162,16 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999933
+      "confidence": 0.999977
     },
     {
       "input": "1 1/4 pounds bittersweet chocolate disks or f\u00e8ves, at least 60 percent cacao content (see note)",
       "name": "bittersweet chocolate disks, bittersweet chocolate f\u00e8ves",
       "qty": 1.25,
       "unit": "pound",
-      "comment": "at least 60.0 percentage cacao content (see note)",
+      "comment": "at least 60 percent cacao content (see note)",
       "other": "",
-      "confidence": 0.999913
+      "confidence": 0.999841
     },
     {
       "input": "Sea salt",

--- a/tests/endpoint/snapshots/cooking.nytimes.com__1023460-challah-bread.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__1023460-challah-bread.json
@@ -111,7 +111,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999958
+      "confidence": 0.999867
     },
     {
       "input": "1/2 cup/72 grams golden raisins (optional)",
@@ -120,7 +120,7 @@
       "unit": "cup",
       "comment": "(optional)",
       "other": "",
-      "confidence": 0.999955
+      "confidence": 0.999927
     },
     {
       "input": "1/3 cup/113 grams honey",
@@ -129,7 +129,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999958
+      "confidence": 0.99993
     },
     {
       "input": "1/3 cup/75 grams extra-virgin olive oil",
@@ -138,7 +138,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999955
+      "confidence": 0.999928
     },
     {
       "input": "1 large egg yolk, at room temperature",
@@ -165,7 +165,7 @@
       "unit": "cup",
       "comment": "plus more for kneading the dough",
       "other": "",
-      "confidence": 0.99996
+      "confidence": 0.999904
     },
     {
       "input": "11 grams kosher salt (about 1 tablespoon Diamond Crystal or 1\u00bd teaspoons Morton coarse kosher salt)",
@@ -174,7 +174,7 @@
       "unit": "gram",
       "comment": "(about 1 tablespoons Diamond Crystal or 1 1/2 teaspoons Morton coarse kosher salt)",
       "other": "",
-      "confidence": 0.999759
+      "confidence": 0.999633
     },
     {
       "input": "Poppy or sesame seeds, for sprinkling (optional)",

--- a/tests/endpoint/snapshots/cooking.nytimes.com__4735-old-fashioned-beef-stew.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__4735-old-fashioned-beef-stew.json
@@ -82,7 +82,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999899
+      "confidence": 0.999978
     },
     {
       "input": "1/4 teaspoon freshly ground pepper",
@@ -109,7 +109,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999973
+      "confidence": 0.999969
     },
     {
       "input": "2 tablespoons red wine vinegar",
@@ -136,7 +136,7 @@
       "unit": "cup",
       "comment": "homemade or low-sodium canned",
       "other": "",
-      "confidence": 0.999888
+      "confidence": 0.999968
     },
     {
       "input": "2 bay leaves",
@@ -161,16 +161,16 @@
       "name": "carrots",
       "qty": 5.0,
       "unit": "",
-      "comment": "peeled and cut into 0.25 inch rounds",
+      "comment": "peeled and cut into 1/4 inch rounds",
       "other": "",
-      "confidence": 0.99988
+      "confidence": 0.999881
     },
     {
       "input": "2 large baking potatoes, peeled and cut into 3/4-inch cubes",
       "name": "baking potatoes",
       "qty": 2.0,
       "unit": "",
-      "comment": "peeled and cut into 0.75 inch cubes",
+      "comment": "peeled and cut into 3/4 inch cubes",
       "other": "",
       "confidence": 0.998638
     },
@@ -181,7 +181,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999849
+      "confidence": 0.999941
     }
   ],
   "error": null,

--- a/tests/endpoint/snapshots/delightbaking.com__little-fluffy-dinner-rolls.json
+++ b/tests/endpoint/snapshots/delightbaking.com__little-fluffy-dinner-rolls.json
@@ -80,12 +80,12 @@
     },
     {
       "input": "350 g Milk 3.5% fat",
-      "name": "Milk, percentage fat",
+      "name": "Milk 3.5% fat",
       "qty": 350.0,
       "unit": "gram",
       "comment": "",
       "other": "",
-      "confidence": 0.992437
+      "confidence": 0.995631
     },
     {
       "input": "75 g Butter",

--- a/tests/endpoint/snapshots/food52.com__65940-gingerbread-dough-for-houses.json
+++ b/tests/endpoint/snapshots/food52.com__65940-gingerbread-dough-for-houses.json
@@ -78,7 +78,7 @@
       "unit": "cup",
       "comment": "at room temperature",
       "other": "",
-      "confidence": 0.999762
+      "confidence": 0.999953
     },
     {
       "input": "1 1/4 cups granulated sugar (250 g)",
@@ -114,7 +114,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999969
+      "confidence": 0.999972
     },
     {
       "input": "1 tablespoon ground cinnamon (9 g)",
@@ -132,7 +132,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.99987
+      "confidence": 0.999638
     },
     {
       "input": "1 1/2 teaspoons baking soda (6 g)",
@@ -141,7 +141,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999964
+      "confidence": 0.999968
     },
     {
       "input": "3/4 teaspoon fine sea salt (3 g)",

--- a/tests/endpoint/snapshots/leelalicious.com__earl-grey-tea-cake.json
+++ b/tests/endpoint/snapshots/leelalicious.com__earl-grey-tea-cake.json
@@ -121,7 +121,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999911
+      "confidence": 0.999958
     },
     {
       "input": "3/4 cup sugar",
@@ -184,7 +184,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999885
+      "confidence": 0.999954
     },
     {
       "input": "1 tablespoon honey",
@@ -211,7 +211,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999953
+      "confidence": 0.999985
     }
   ],
   "error": null,
@@ -264,7 +264,7 @@
     {
       "name": "calories",
       "amount": 201.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     }
   ]
 }

--- a/tests/endpoint/snapshots/preppykitchen.com__chocolate-chip-banana-bread.json
+++ b/tests/endpoint/snapshots/preppykitchen.com__chocolate-chip-banana-bread.json
@@ -88,7 +88,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999922
+      "confidence": 0.999979
     },
     {
       "input": "1 teaspoon baking powder",
@@ -177,7 +177,7 @@
     {
       "name": "calories",
       "amount": 309.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/prettysimplesweet.com__chocolate-buns-2.json
+++ b/tests/endpoint/snapshots/prettysimplesweet.com__chocolate-buns-2.json
@@ -62,7 +62,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999895
+      "confidence": 0.999771
     },
     {
       "input": "3 tablespoons (20g) cocoa powder (I use Dutch process)",
@@ -71,7 +71,7 @@
       "unit": "tablespoon",
       "comment": "(I use Dutch process)",
       "other": "",
-      "confidence": 0.999909
+      "confidence": 0.999834
     },
     {
       "input": "6 tablespoons (75g) granulated sugar",
@@ -80,7 +80,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999898
+      "confidence": 0.999795
     },
     {
       "input": "2\u00bc teaspoons (7g) instant yeast",
@@ -89,7 +89,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999845
+      "confidence": 0.999665
     },
     {
       "input": "1\u00bd teaspoons salt",
@@ -98,7 +98,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999849
+      "confidence": 0.999941
     },
     {
       "input": "1 cup (240 ml) water, lukewarm",

--- a/tests/endpoint/snapshots/sallysbakingaddiction.com__spinach-bacon-breakfast-strata.json
+++ b/tests/endpoint/snapshots/sallysbakingaddiction.com__spinach-bacon-breakfast-strata.json
@@ -82,7 +82,7 @@
       "unit": "cup",
       "comment": "cubed",
       "other": "",
-      "confidence": 0.999218
+      "confidence": 0.998827
     },
     {
       "input": "8 slices uncooked bacon",
@@ -123,11 +123,11 @@
     {
       "input": "1 and 1/2 cups shredded parmesan cheese",
       "name": "parmesan cheese",
-      "qty": 1.0,
+      "qty": 1.5,
       "unit": "cup",
       "comment": "shredded",
       "other": "",
-      "confidence": 0.999682
+      "confidence": 0.999778
     },
     {
       "input": "9 large eggs",
@@ -145,7 +145,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999954
+      "confidence": 0.999989
     },
     {
       "input": "1 teaspoon salt",

--- a/tests/endpoint/snapshots/thedomesticrebel.com__levain-bakery-style-ultimate-peanut-butter-cookies.json
+++ b/tests/endpoint/snapshots/thedomesticrebel.com__levain-bakery-style-ultimate-peanut-butter-cookies.json
@@ -156,7 +156,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999899
+      "confidence": 0.999976
     },
     {
       "input": "2 cups peanut butter chips",
@@ -165,7 +165,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.99994
+      "confidence": 0.999978
     },
     {
       "input": "1\u00bd cups Reese's Pieces candies",
@@ -174,7 +174,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999994
+      "confidence": 0.99999
     }
   ],
   "error": null,

--- a/tests/endpoint/snapshots/therecipecritic.com__crispy-parmesan-garlic-chicken-zucchini.json
+++ b/tests/endpoint/snapshots/therecipecritic.com__crispy-parmesan-garlic-chicken-zucchini.json
@@ -78,7 +78,7 @@
       "unit": "tablespoon",
       "comment": "(divided)",
       "other": "",
-      "confidence": 0.999948
+      "confidence": 0.999968
     },
     {
       "input": "\u00bd cup Italian Bread Crumbs",
@@ -96,7 +96,7 @@
       "unit": "cup",
       "comment": "grated, (divided)",
       "other": "",
-      "confidence": 0.999901
+      "confidence": 0.999838
     },
     {
       "input": "\u00bc cup flour",
@@ -105,7 +105,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999975
+      "confidence": 0.999938
     },
     {
       "input": "2 medium zucchini (sliced)",
@@ -131,7 +131,7 @@
     {
       "name": "calories",
       "amount": 418.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.bonappetit.com__best-pumpkin-pie.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__best-pumpkin-pie.json
@@ -179,7 +179,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999942
+      "confidence": 0.999671
     },
     {
       "input": "2 tsp. vanilla extract",

--- a/tests/endpoint/snapshots/www.bonappetit.com__cabbage-roll-casserole.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__cabbage-roll-casserole.json
@@ -139,7 +139,7 @@
       "unit": "tablespoon",
       "comment": "divided",
       "other": "",
-      "confidence": 0.999942
+      "confidence": 0.999937
     },
     {
       "input": "1 large onion",
@@ -193,7 +193,7 @@
       "unit": "cup",
       "comment": "(such as basmati)",
       "other": "",
-      "confidence": 0.999718
+      "confidence": 0.999946
     },
     {
       "input": "1 lemon",

--- a/tests/endpoint/snapshots/www.bonappetit.com__cheesesteaks.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__cheesesteaks.json
@@ -78,25 +78,25 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999979
+      "confidence": 0.999974
     },
     {
       "input": "4 large onions, sliced \u00bc inch thick",
       "name": "onions",
       "qty": 4.0,
       "unit": "",
-      "comment": "sliced 0.25 inch thick",
+      "comment": "sliced 1/4 inch thick",
       "other": "",
-      "confidence": 0.999566
+      "confidence": 0.999568
     },
     {
       "input": "3 large red and/or green bell peppers, seeds removed, sliced \u00bc inch thick",
       "name": "red bell peppers, green bell peppers",
       "qty": 3.0,
       "unit": "",
-      "comment": "seeds removed, sliced 0.25 inch thick",
+      "comment": "seeds removed, sliced 1/4 inch thick",
       "other": "",
-      "confidence": 0.999146
+      "confidence": 0.999145
     },
     {
       "input": "Kosher salt, freshly ground pepper",
@@ -114,7 +114,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999727
+      "confidence": 0.99994
     },
     {
       "input": "4 pounds boneless beef short ribs",
@@ -123,7 +123,7 @@
       "unit": "pound",
       "comment": "",
       "other": "",
-      "confidence": 0.999974
+      "confidence": 0.999968
     },
     {
       "input": "8 10-inch-long Italian sub rolls",
@@ -168,7 +168,7 @@
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999966
+      "confidence": 0.999967
     },
     {
       "input": "10 ounces mild or sharp provolone slices (about 16)",
@@ -177,7 +177,7 @@
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999973
+      "confidence": 0.999974
     },
     {
       "input": "Ketchup and/or hot sauce (for serving; optional)",

--- a/tests/endpoint/snapshots/www.bonappetit.com__chicken-scarpariello.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__chicken-scarpariello.json
@@ -74,7 +74,7 @@
       "unit": "pound",
       "comment": "halved lengthwise",
       "other": "",
-      "confidence": 0.999839
+      "confidence": 0.999884
     },
     {
       "input": "6 tablespoons extra-virgin olive oil, divided",
@@ -83,7 +83,7 @@
       "unit": "tablespoon",
       "comment": "divided",
       "other": "",
-      "confidence": 0.999959
+      "confidence": 0.999979
     },
     {
       "input": "Kosher salt, freshly ground pepper",
@@ -173,7 +173,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999964
+      "confidence": 0.999988
     },
     {
       "input": "3 sprigs rosemary",

--- a/tests/endpoint/snapshots/www.bonappetit.com__mama-rosas-lasagna-de-carne.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__mama-rosas-lasagna-de-carne.json
@@ -101,12 +101,12 @@
     },
     {
       "input": "1 plum tomato, coarsely chopped",
-      "name": "atomic mass units metre tomato",
+      "name": "plum tomato",
       "qty": 1.0,
-      "unit": "liter * pint",
+      "unit": "",
       "comment": "coarsely chopped",
       "other": "",
-      "confidence": 0.991976
+      "confidence": 0.998527
     },
     {
       "input": "4 sprigs cilantro",
@@ -187,7 +187,7 @@
       "unit": "tablespoon",
       "comment": "or 1 3/4 teaspoons Morton kosher salt, plus more",
       "other": "",
-      "confidence": 0.999839
+      "confidence": 0.997084
     },
     {
       "input": "1 Tbsp. extra-virgin olive oil",
@@ -196,14 +196,14 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999959
+      "confidence": 0.999948
     },
     {
       "input": "2 lb. ground beef chuck (10% fat)",
       "name": "ground beef chuck",
       "qty": 2.0,
       "unit": "pound",
-      "comment": "(10.0 percentage fat)",
+      "comment": "(10% fat)",
       "other": "",
       "confidence": 0.999931
     },
@@ -214,7 +214,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999937
+      "confidence": 0.999659
     },
     {
       "input": "2 bay leaves",

--- a/tests/endpoint/snapshots/www.bonappetit.com__roasted-broccoli.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__roasted-broccoli.json
@@ -63,7 +63,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999979
+      "confidence": 0.99967
     },
     {
       "input": "Kosher salt, freshly ground black pepper",

--- a/tests/endpoint/snapshots/www.bonappetit.com__seafood-chowder.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__seafood-chowder.json
@@ -73,7 +73,7 @@
       "unit": "tablespoon",
       "comment": "divided",
       "other": "",
-      "confidence": 0.999972
+      "confidence": 0.999846
     },
     {
       "input": "1 large onion, finely chopped",
@@ -100,7 +100,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999979
+      "confidence": 0.999305
     },
     {
       "input": "1 tsp. freshly ground black pepper, plus more",
@@ -118,7 +118,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.99992
+      "confidence": 0.999006
     },
     {
       "input": "2\u00bd cups clam juice, divided",
@@ -127,7 +127,7 @@
       "unit": "cup",
       "comment": "divided",
       "other": "",
-      "confidence": 0.999936
+      "confidence": 0.999979
     },
     {
       "input": "2 cups fish or seafood stock or broth",
@@ -136,23 +136,23 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.99898
+      "confidence": 0.999911
     },
     {
       "input": "1 lb. potatoes (any kind), peeled, cut into \u00bd\" pieces",
-      "name": "sterling potatoes",
+      "name": "potatoes",
       "qty": 1.0,
       "unit": "pound",
-      "comment": "peeled, cut into 0.5 inch pieces",
+      "comment": "peeled, cut into 1/2 inch pieces",
       "other": "",
-      "confidence": 0.999926
+      "confidence": 0.999558
     },
     {
       "input": "1\u00bc lb. mixed white fish (such as swordfish, sea bass, and/or halibut) and shellfish (such as lump crab meat, scallops and/or peeled, deveined shrimp), cut into \u00bd\" pieces",
       "name": "mixed white fish",
       "qty": 1.25,
       "unit": "pound",
-      "comment": "cut into 0.5 inch pieces",
+      "comment": "cut into 1/2 inch pieces",
       "other": "",
       "confidence": 0.999962
     },
@@ -172,7 +172,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999856
+      "confidence": 0.999817
     },
     {
       "input": "\u00bd cup half-and-half",
@@ -181,7 +181,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999833
+      "confidence": 0.999913
     }
   ],
   "error": null,

--- a/tests/endpoint/snapshots/www.budgetbytes.com__beef-cabbage-stir-fry.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__beef-cabbage-stir-fry.json
@@ -65,43 +65,43 @@
   "ingredients": [
     {
       "input": "2 Tbsp soy sauce ($0.18)",
-      "name": "soy sauce -#9$50 dollar",
+      "name": "soy sauce",
       "qty": 2.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999927
+      "confidence": 0.999354
     },
     {
       "input": "1 Tbsp toasted sesame oil ($0.33)",
-      "name": "toasted sesame oil -#33$100 dollar",
+      "name": "toasted sesame oil",
       "qty": 1.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999948
+      "confidence": 0.999826
     },
     {
       "input": "1 Tbsp sriracha* ( $0.05)",
       "name": "sriracha",
       "qty": 1.0,
       "unit": "tablespoon",
-      "comment": "(0.05 dollar)",
+      "comment": "",
       "other": "",
-      "confidence": 0.999951
+      "confidence": 0.999265
     },
     {
       "input": "1/2 Tbsp brown sugar ( $0.02)",
       "name": "brown sugar",
       "qty": 0.5,
       "unit": "tablespoon",
-      "comment": "(0.02 dollar)",
+      "comment": "",
       "other": "",
-      "confidence": 0.999976
+      "confidence": 0.999912
     },
     {
       "input": "1/2 head green cabbage ($1.78)",
-      "name": "green cabbage -1-#39$50 dollar",
+      "name": "green cabbage",
       "qty": 0.5,
       "unit": "heads",
       "comment": "",
@@ -110,48 +110,48 @@
     },
     {
       "input": "2 carrots ($0.22)",
-      "name": "carrots -#11$50 dollar",
+      "name": "carrots",
       "qty": 2.0,
       "unit": "",
       "comment": "",
       "other": "",
-      "confidence": 0.999581
+      "confidence": 0.999739
     },
     {
       "input": "3 green onions ($0.17)",
-      "name": "green onions -#17$100 dollar",
+      "name": "green onions",
       "qty": 3.0,
       "unit": "",
       "comment": "",
       "other": "",
-      "confidence": 0.999455
+      "confidence": 0.99971
     },
     {
       "input": "1/2 Tbsp neutral cooking oil ($0.02)",
-      "name": "neutral cooking oil -#1$50 dollar",
+      "name": "neutral cooking oil",
       "qty": 0.5,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999977
+      "confidence": 0.999914
     },
     {
       "input": "1/2 lb. lean ground beef ($3.90)",
-      "name": "lean ground beef -3-#9$10 dollar",
+      "name": "lean ground beef",
       "qty": 0.5,
       "unit": "pound",
       "comment": "",
       "other": "",
-      "confidence": 0.999852
+      "confidence": 0.99988
     },
     {
       "input": "2 cloves garlic ($0.16)",
-      "name": "garlic -#4$25 dollar",
+      "name": "garlic",
       "qty": 2.0,
       "unit": "cloves",
       "comment": "",
       "other": "",
-      "confidence": 0.999886
+      "confidence": 0.999259
     },
     {
       "input": "1 Tbsp fresh grated ginger ( $0.13)",
@@ -160,34 +160,34 @@
       "unit": "tablespoon",
       "comment": "grated",
       "other": "",
-      "confidence": 0.999937
+      "confidence": 0.999726
     },
     {
       "input": "Pinch of salt and pepper ($0.05)",
-      "name": "salt, pepper -#1$20 dollar",
+      "name": "salt, pepper",
       "qty": 1.0,
       "unit": "Pinch",
       "comment": "",
       "other": "",
-      "confidence": 0.996478
+      "confidence": 0.998295
     },
     {
       "input": "1 Tbsp sesame seeds ($0.08)",
-      "name": "sesame seeds -#2$25 dollar",
+      "name": "sesame seeds",
       "qty": 1.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999958
+      "confidence": 0.999532
     },
     {
       "input": "1 Tbsp sriracha ($0.05)",
-      "name": "sriracha -#1$20 dollar",
+      "name": "sriracha",
       "qty": 1.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999916
+      "confidence": 0.999052
     }
   ],
   "error": null,
@@ -195,7 +195,7 @@
     {
       "name": "calories",
       "amount": 195.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__easy-pesto-chicken-and-vegetables.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__easy-pesto-chicken-and-vegetables.json
@@ -80,61 +80,61 @@
   "ingredients": [
     {
       "input": "1 red bell pepper ($1.50)",
-      "name": "red bell pepper -1-#1$2 dollar",
+      "name": "red bell pepper",
       "qty": 1.0,
       "unit": "",
       "comment": "",
       "other": "",
-      "confidence": 0.999261
+      "confidence": 0.99946
     },
     {
       "input": "1 zucchini ($0.60)",
-      "name": "zucchini -#3$5 dollar",
+      "name": "zucchini",
       "qty": 1.0,
       "unit": "",
       "comment": "",
       "other": "",
-      "confidence": 0.999493
+      "confidence": 0.99982
     },
     {
       "input": "1 yellow squash ($0.50)",
-      "name": "yellow squash -#1$2 dollar",
+      "name": "yellow squash",
       "qty": 1.0,
       "unit": "",
       "comment": "",
       "other": "",
-      "confidence": 0.999707
+      "confidence": 0.999713
     },
     {
       "input": "1/2 red onion ($0.19)",
-      "name": "red onion -#19$100 dollar",
+      "name": "red onion",
       "qty": 0.5,
       "unit": "",
       "comment": "",
       "other": "",
-      "confidence": 0.998923
+      "confidence": 0.999758
     },
     {
       "input": "1.3 lbs. boneless, skinless chicken breast ($6.67)",
-      "name": "boneless, skinless chicken breast -6-#67$100 dollar",
+      "name": "boneless, skinless chicken breast",
       "qty": 1.3,
       "unit": "pound",
       "comment": "",
       "other": "",
-      "confidence": 0.999978
+      "confidence": 0.999181
     },
     {
       "input": "2 Tbsp cooking oil ($0.08)",
-      "name": "cooking oil -#2$25 dollar",
+      "name": "cooking oil",
       "qty": 2.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999749
+      "confidence": 0.999387
     },
     {
       "input": "1 cup frozen green beans ($0.67)",
-      "name": "frozen green beans -#67$100 dollar",
+      "name": "frozen green beans",
       "qty": 1.0,
       "unit": "cup",
       "comment": "",
@@ -143,39 +143,39 @@
     },
     {
       "input": "1/3 cup pesto* ($0.73)",
-      "name": "pesto* -#73$100 dollar",
+      "name": "pesto",
       "qty": 0.333,
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999931
+      "confidence": 0.999924
     },
     {
       "input": "1/8 tsp salt* ($0.01)",
-      "name": "salt* -#1$100 dollar",
+      "name": "salt",
       "qty": 0.125,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999894
+      "confidence": 0.999895
     },
     {
       "input": "1/8 tsp freshly cracked pepper* ($0.01)",
-      "name": "pepper, -#1$100 dollar",
+      "name": "pepper",
       "qty": 0.125,
       "unit": "teaspoon",
       "comment": "freshly cracked",
       "other": "",
-      "confidence": 0.999662
+      "confidence": 0.99976
     },
     {
       "input": "1 Tbsp grated Parmesan* ($0.11)",
-      "name": "Parmesan* -#11$100 dollar",
+      "name": "Parmesan",
       "qty": 1.0,
       "unit": "tablespoon",
       "comment": "grated",
       "other": "",
-      "confidence": 0.999657
+      "confidence": 0.996387
     }
   ],
   "error": null,
@@ -188,7 +188,7 @@
     {
       "name": "calories",
       "amount": 369.33,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__fried-cabbage-and-noodles.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__fried-cabbage-and-noodles.json
@@ -66,55 +66,55 @@
   "ingredients": [
     {
       "input": "2 Tbsp cooking oil ($0.08)",
-      "name": "cooking oil -#2$25 dollar",
+      "name": "cooking oil",
       "qty": 2.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999749
+      "confidence": 0.999387
     },
     {
       "input": "1 yellow onion ($0.32)",
-      "name": "yellow onion -#8$25 dollar",
+      "name": "yellow onion",
       "qty": 1.0,
       "unit": "",
       "comment": "",
       "other": "",
-      "confidence": 0.999213
+      "confidence": 0.999788
     },
     {
       "input": "8 oz. wide egg noodles ($0.90)",
-      "name": "wide egg noodles -#9$10 dollar",
+      "name": "wide egg noodles",
       "qty": 8.0,
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999061
+      "confidence": 0.998749
     },
     {
       "input": "1/2 head cabbage (4-5 cups sliced) ($1.28)",
-      "name": "cabbage, -1-#7$25 dollar",
+      "name": "cabbage",
       "qty": 0.5,
       "unit": "heads",
       "comment": "sliced",
       "other": "",
-      "confidence": 0.999497
+      "confidence": 0.999383
     },
     {
       "input": "2 Tbsp butter ($0.20)",
-      "name": "butter -#1$5 dollar",
+      "name": "butter",
       "qty": 2.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999942
+      "confidence": 0.999405
     },
     {
       "input": "salt and pepper to taste ($0.05)",
       "name": "salt, pepper",
       "qty": 1.0,
       "unit": "",
-      "comment": "to taste -#1$20 dollar",
+      "comment": "to taste",
       "other": "",
       "confidence": 0.0
     }
@@ -124,7 +124,7 @@
     {
       "name": "calories",
       "amount": 370.5,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__one-pot-creamy-cajun-chicken-pasta.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__one-pot-creamy-cajun-chicken-pasta.json
@@ -82,156 +82,156 @@
   "ingredients": [
     {
       "input": "2 tsp smoked paprika ($0.20)",
-      "name": "smoked paprika -#1$5 dollar",
+      "name": "smoked paprika",
       "qty": 2.0,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999934
+      "confidence": 0.999954
     },
     {
       "input": "1 tsp oregano ($0.10)",
-      "name": "oregano -#1$10 dollar",
+      "name": "oregano",
       "qty": 1.0,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.99993
+      "confidence": 0.999847
     },
     {
       "input": "1 tsp thyme ($0.10)",
-      "name": "thyme -#1$10 dollar",
+      "name": "thyme",
       "qty": 1.0,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999824
+      "confidence": 0.999877
     },
     {
       "input": "1/2 tsp garlic powder ($0.05)",
-      "name": "garlic powder -#1$20 dollar",
+      "name": "garlic powder",
       "qty": 0.5,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999974
+      "confidence": 0.999973
     },
     {
       "input": "1/2 tsp onion powder ($0.05)",
-      "name": "onion powder -#1$20 dollar",
+      "name": "onion powder",
       "qty": 0.5,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999811
+      "confidence": 0.999883
     },
     {
       "input": "1/4 tsp cayenne pepper ($0.03)",
-      "name": "cayenne pepper -#3$100 dollar",
+      "name": "cayenne pepper",
       "qty": 0.25,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.99994
+      "confidence": 0.999938
     },
     {
       "input": "1/4 tsp black pepper ($0.02)",
-      "name": "black pepper -#1$50 dollar",
+      "name": "black pepper",
       "qty": 0.25,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.99997
+      "confidence": 0.99996
     },
     {
       "input": "1/4 tsp salt ($0.02)",
-      "name": "salt -#1$50 dollar",
+      "name": "salt",
       "qty": 0.25,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999888
+      "confidence": 0.999849
     },
     {
       "input": "1 Tbsp olive oil ($0.16)",
-      "name": "olive oil -#4$25 dollar",
+      "name": "olive oil",
       "qty": 1.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999962
+      "confidence": 0.99967
     },
     {
       "input": "1 Tbsp butter ($0.13)",
-      "name": "butter -#13$100 dollar",
+      "name": "butter",
       "qty": 1.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999942
+      "confidence": 0.999405
     },
     {
       "input": "1 lb. boneless, skinless chicken breast ($5.47)",
-      "name": "boneless, skinless chicken breast -5-#47$100 dollar",
+      "name": "boneless, skinless chicken breast",
       "qty": 1.0,
       "unit": "pound",
       "comment": "",
       "other": "",
-      "confidence": 0.999978
+      "confidence": 0.999985
     },
     {
       "input": "1 yellow onion, diced ($0.32)",
       "name": "yellow onion",
       "qty": 1.0,
       "unit": "",
-      "comment": "diced -#8$25 dollar",
+      "comment": "diced",
       "other": "",
       "confidence": 0.999879
     },
     {
       "input": "1/2 lb. penne pasta (uncooked) ($0.75)",
-      "name": "penne pasta, -#3$4 dollar",
+      "name": "penne pasta",
       "qty": 0.5,
       "unit": "pound",
       "comment": "(uncooked)",
       "other": "",
-      "confidence": 0.999946
+      "confidence": 0.999958
     },
     {
       "input": "15 oz. fire roasted diced tomatoes ($1.00)",
-      "name": "fire roasted diced tomatoes -1 dollar",
+      "name": "fire roasted diced tomatoes",
       "qty": 15.0,
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999801
+      "confidence": 0.999854
     },
     {
       "input": "2 cups chicken broth ($0.26)",
-      "name": "chicken broth -#13$50 dollar",
+      "name": "chicken broth",
       "qty": 2.0,
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.99996
+      "confidence": 0.999987
     },
     {
       "input": "2 oz. cream cheese ($0.50)",
-      "name": "cream cheese -#1$2 dollar",
+      "name": "cream cheese",
       "qty": 2.0,
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999731
+      "confidence": 0.999605
     },
     {
       "input": "3 green onions, sliced ($0.25)",
       "name": "green onions",
       "qty": 3.0,
       "unit": "",
-      "comment": "sliced -#1$4 dollar",
+      "comment": "sliced",
       "other": "",
-      "confidence": 0.999923
+      "confidence": 0.99992
     }
   ],
   "error": null,
@@ -239,7 +239,7 @@
     {
       "name": "calories",
       "amount": 482.65,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__unstuffed-bell-peppers.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__unstuffed-bell-peppers.json
@@ -84,61 +84,61 @@
   "ingredients": [
     {
       "input": "1 clove garlic ($0.08)",
-      "name": "garlic -#2$25 dollar",
+      "name": "garlic",
       "qty": 1.0,
       "unit": "clove",
       "comment": "",
       "other": "",
-      "confidence": 0.99884
+      "confidence": 0.995637
     },
     {
       "input": "1 yellow onion ($0.32)",
-      "name": "yellow onion -#8$25 dollar",
+      "name": "yellow onion",
       "qty": 1.0,
       "unit": "",
       "comment": "",
       "other": "",
-      "confidence": 0.999213
+      "confidence": 0.999788
     },
     {
       "input": "2 bell peppers ($1.53)",
-      "name": "bell peppers -1-#53$100 dollar",
+      "name": "bell peppers",
       "qty": 2.0,
       "unit": "",
       "comment": "",
       "other": "",
-      "confidence": 0.999255
+      "confidence": 0.999714
     },
     {
       "input": "1 Tbsp olive oil ($0.16)",
-      "name": "olive oil -#4$25 dollar",
+      "name": "olive oil",
       "qty": 1.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999962
+      "confidence": 0.99967
     },
     {
       "input": "1/2 lb. ground beef ($2.85)",
-      "name": "ground beef -2-#17$20 dollar",
+      "name": "ground beef",
       "qty": 0.5,
       "unit": "pound",
       "comment": "",
       "other": "",
-      "confidence": 0.999927
+      "confidence": 0.999946
     },
     {
       "input": "1 15oz. can diced tomatoes ($1.00)",
-      "name": "diced tomatoes -1 dollar",
+      "name": "diced tomatoes",
       "qty": 1.0,
       "unit": "can",
       "comment": "",
       "other": "",
-      "confidence": 0.999647
+      "confidence": 0.999747
     },
     {
       "input": "1 cup long grain white rice (uncooked) ($0.62)",
-      "name": "long grain white rice, -#31$50 dollar",
+      "name": "long grain white rice",
       "qty": 1.0,
       "unit": "cup",
       "comment": "(uncooked)",
@@ -147,75 +147,75 @@
     },
     {
       "input": "1 tsp dried basil ($0.10)",
-      "name": "dried basil -#1$10 dollar",
+      "name": "dried basil",
       "qty": 1.0,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999842
+      "confidence": 0.999919
     },
     {
       "input": "1 tsp dried oregano ($0.10)",
-      "name": "dried oregano -#1$10 dollar",
+      "name": "dried oregano",
       "qty": 1.0,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999946
+      "confidence": 0.999936
     },
     {
       "input": "1/4 tsp freshly cracked black pepper ($0.02)",
-      "name": "black pepper -#1$50 dollar",
+      "name": "black pepper",
       "qty": 0.25,
       "unit": "teaspoon",
       "comment": "freshly cracked",
       "other": "",
-      "confidence": 0.999876
+      "confidence": 0.999909
     },
     {
       "input": "1.5 cups beef broth ($0.07)",
-      "name": "beef broth -#7$100 dollar",
+      "name": "beef broth",
       "qty": 1.5,
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.99995
+      "confidence": 0.999984
     },
     {
       "input": "1 8oz. can tomato sauce ($0.26)",
-      "name": "tomato sauce -#13$50 dollar",
+      "name": "tomato sauce",
       "qty": 1.0,
       "unit": "can",
       "comment": "",
       "other": "",
-      "confidence": 0.999836
+      "confidence": 0.999855
     },
     {
       "input": "1 tsp Worcestershire sauce ($0.01)",
-      "name": "Worcestershire sauce -#1$100 dollar",
+      "name": "Worcestershire sauce",
       "qty": 1.0,
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999981
+      "confidence": 0.999979
     },
     {
       "input": "1 cup shredded mozzarella ($0.85)",
-      "name": "mozzarella -#17$20 dollar",
+      "name": "mozzarella",
       "qty": 1.0,
       "unit": "cup",
       "comment": "shredded",
       "other": "",
-      "confidence": 0.999959
+      "confidence": 0.999938
     },
     {
       "input": "1 Tbsp chopped parsley (optional garnish) ($0.05)",
-      "name": "parsley, -#1$20 dollar",
+      "name": "parsley",
       "qty": 1.0,
       "unit": "tablespoon",
       "comment": "chopped",
       "other": "",
-      "confidence": 0.999896
+      "confidence": 0.998865
     }
   ],
   "error": null,
@@ -228,7 +228,7 @@
     {
       "name": "calories",
       "amount": 320.53,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.cookingchanneltv.com__baked-potato-fries-reloaded-5470330.json
+++ b/tests/endpoint/snapshots/www.cookingchanneltv.com__baked-potato-fries-reloaded-5470330.json
@@ -58,12 +58,12 @@
   "ingredients": [
     {
       "input": "4 russet potatoes (about 8 ounces/227 grams each), scrubbed and rinsed",
-      "name": "roentgen atomic mass units second set potatoes",
+      "name": "russet potatoes",
       "qty": 4.0,
       "unit": "",
       "comment": "scrubbed and rinsed",
       "other": "",
-      "confidence": 0.996987
+      "confidence": 0.999163
     },
     {
       "input": "2 teaspoons plus 2 quarts peanut oil",
@@ -72,7 +72,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999789
+      "confidence": 0.99918
     },
     {
       "input": "Kosher salt",

--- a/tests/endpoint/snapshots/www.foodnetwork.com__baked-macaroni-and-cheese-recipe-1939524.json
+++ b/tests/endpoint/snapshots/www.foodnetwork.com__baked-macaroni-and-cheese-recipe-1939524.json
@@ -102,7 +102,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999939
+      "confidence": 0.999971
     },
     {
       "input": "3 tablespoons flour",
@@ -111,7 +111,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.99992
+      "confidence": 0.999963
     },
     {
       "input": "1 tablespoon powdered mustard",
@@ -129,7 +129,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999844
+      "confidence": 0.99995
     },
     {
       "input": "1/2 cup yellow onion, finely diced",
@@ -174,7 +174,7 @@
       "unit": "ounce",
       "comment": "shredded",
       "other": "",
-      "confidence": 0.999942
+      "confidence": 0.999921
     },
     {
       "input": "1 teaspoon kosher salt",
@@ -201,7 +201,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999939
+      "confidence": 0.999971
     },
     {
       "input": "1 cup panko bread crumbs",

--- a/tests/endpoint/snapshots/www.foodnetwork.com__instant-pancake-mix-recipe-1938544.json
+++ b/tests/endpoint/snapshots/www.foodnetwork.com__instant-pancake-mix-recipe-1938544.json
@@ -91,7 +91,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999899
+      "confidence": 0.999976
     },
     {
       "input": "1 1/2 teaspoons baking soda (check expiration date first)",
@@ -100,7 +100,7 @@
       "unit": "teaspoon",
       "comment": "(check expiration date first)",
       "other": "",
-      "confidence": 0.999968
+      "confidence": 0.999972
     },
     {
       "input": "3 teaspoons baking powder",
@@ -109,7 +109,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999936
+      "confidence": 0.999963
     },
     {
       "input": "1 tablespoon kosher salt",
@@ -127,7 +127,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999885
+      "confidence": 0.999954
     },
     {
       "input": "2 eggs, separated",
@@ -145,7 +145,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999931
+      "confidence": 0.999969
     },
     {
       "input": "4 tablespoons melted butter",
@@ -154,7 +154,7 @@
       "unit": "tablespoon",
       "comment": "melted",
       "other": "",
-      "confidence": 0.999521
+      "confidence": 0.999496
     },
     {
       "input": "2 cups \"Instant\" Pancake Mix, recipe above",
@@ -163,7 +163,7 @@
       "unit": "cup",
       "comment": "recipes above",
       "other": "",
-      "confidence": 0.999981
+      "confidence": 0.999971
     },
     {
       "input": "1 stick butter, for greasing the pan",
@@ -181,7 +181,7 @@
       "unit": "cup",
       "comment": "such as blueberries, if desired",
       "other": "",
-      "confidence": 0.999978
+      "confidence": 0.999979
     }
   ],
   "error": null,

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__brown-butter-oatmeal-chocolate-chip-cookies.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__brown-butter-oatmeal-chocolate-chip-cookies.json
@@ -95,7 +95,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999899
+      "confidence": 0.999976
     },
     {
       "input": "2 cups old fashioned oats",
@@ -104,7 +104,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999979
+      "confidence": 0.999977
     },
     {
       "input": "1 teaspoon baking soda",
@@ -131,7 +131,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999961
+      "confidence": 0.999976
     },
     {
       "input": "flaky sea salt, for sprinkling ((optional))",
@@ -148,7 +148,7 @@
     {
       "name": "calories",
       "amount": 279.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     }
   ]
 }

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__chicken-gyros-with-feta-tzatziki.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__chicken-gyros-with-feta-tzatziki.json
@@ -70,7 +70,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999948
+      "confidence": 0.999987
     },
     {
       "input": "1/4 cup extra virgin olive oil",
@@ -88,7 +88,7 @@
       "unit": "pound",
       "comment": "cubed",
       "other": "",
-      "confidence": 0.999932
+      "confidence": 0.999849
     },
     {
       "input": "1/4 cup fresh lemon juice",
@@ -178,7 +178,7 @@
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999776
+      "confidence": 0.999927
     },
     {
       "input": "1/4 cup + 1/3 cup plain Greek yogurt",
@@ -187,7 +187,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999958
+      "confidence": 0.999962
     },
     {
       "input": "2 cloves garlic grated",
@@ -231,7 +231,7 @@
     {
       "name": "calories",
       "amount": 1205.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__chili-crisp-peanut-noodles.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__chili-crisp-peanut-noodles.json
@@ -63,7 +63,7 @@
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999639
+      "confidence": 0.999847
     },
     {
       "input": "1/2 cup creamy peanut butter",
@@ -90,7 +90,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999911
+      "confidence": 0.999958
     },
     {
       "input": "1/4 cup Thai red curry paste",
@@ -133,7 +133,7 @@
       "name": "",
       "qty": 1.0,
       "unit": "tablespoon",
-      "comment": "plus 0.25 cups sesame oil",
+      "comment": "plus 1/4 cups sesame oil",
       "other": "",
       "confidence": 0.999691
     },
@@ -144,7 +144,7 @@
       "unit": "ounce",
       "comment": "cubed and patted dry",
       "other": "",
-      "confidence": 0.99972
+      "confidence": 0.999844
     },
     {
       "input": "6 cloves garlic, chopped",
@@ -198,7 +198,7 @@
       "unit": "tablespoon",
       "comment": "chopped",
       "other": "",
-      "confidence": 0.999789
+      "confidence": 0.9997
     },
     {
       "input": "2 tablespoons lime juice",
@@ -207,7 +207,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999914
+      "confidence": 0.999973
     }
   ],
   "error": null,
@@ -215,7 +215,7 @@
     {
       "name": "calories",
       "amount": 496.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     }
   ]
 }

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__creamy-parmesan-chicken-and-spinach-tortellini.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__creamy-parmesan-chicken-and-spinach-tortellini.json
@@ -77,7 +77,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999899
+      "confidence": 0.999978
     },
     {
       "input": "1 teaspoon garlic powder",
@@ -95,7 +95,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999974
+      "confidence": 0.99997
     },
     {
       "input": "2 tablespoons salted butter",
@@ -104,7 +104,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999943
+      "confidence": 0.999942
     },
     {
       "input": "2 shallots, finely chopped",
@@ -131,7 +131,7 @@
       "unit": "tablespoon",
       "comment": "((or 2 teaspoons dried thyme))",
       "other": "",
-      "confidence": 0.999856
+      "confidence": 0.999869
     },
     {
       "input": "red pepper flakes",
@@ -211,7 +211,7 @@
     {
       "name": "calories",
       "amount": 732.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     }
   ]
 }

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__green-chile-chicken.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__green-chile-chicken.json
@@ -69,7 +69,7 @@
       "unit": "ounce",
       "comment": "at room temperature",
       "other": "",
-      "confidence": 0.999243
+      "confidence": 0.999839
     },
     {
       "input": "4 slices pepperjack cheese",
@@ -141,7 +141,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999974
+      "confidence": 0.99997
     },
     {
       "input": "1 jar salsa verde",
@@ -167,7 +167,7 @@
     {
       "name": "calories",
       "amount": 550.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     }
   ]
 }

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__korean-beef-sesame-noodles.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__korean-beef-sesame-noodles.json
@@ -97,16 +97,16 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999914
+      "confidence": 0.999972
     },
     {
       "input": "2-3 tablespoons Gochujang ((Korean chili paste))",
       "name": "Gochujang",
-      "qty": 2.5,
+      "qty": 2.0,
       "unit": "tablespoon",
       "comment": "((Korean chili paste))",
       "other": "",
-      "confidence": 0.999963
+      "confidence": 0.999951
     },
     {
       "input": "1 tablespoon toasted sesame oil",
@@ -124,7 +124,7 @@
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999872
+      "confidence": 0.99988
     },
     {
       "input": "2 tablespoons sesame oil",
@@ -133,7 +133,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999929
+      "confidence": 0.999978
     },
     {
       "input": "3 cups mixed stir fry vegetables",
@@ -142,7 +142,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.99998
+      "confidence": 0.999985
     },
     {
       "input": "3 shallots, sliced",
@@ -186,7 +186,7 @@
     {
       "name": "calories",
       "amount": 740.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     }
   ]
 }

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__one-pot-hamburger-helper.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__one-pot-hamburger-helper.json
@@ -56,7 +56,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999974
+      "confidence": 0.99997
     },
     {
       "input": "1 pound lean ground beef",
@@ -137,7 +137,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999969
+      "confidence": 0.999963
     },
     {
       "input": "1 1/2 cups milk ((use what you drink))",
@@ -146,7 +146,7 @@
       "unit": "cup",
       "comment": "((use what you drink))",
       "other": "",
-      "confidence": 0.999865
+      "confidence": 0.999963
     },
     {
       "input": "1 1/2-2 cups shredded cheddar cheese",
@@ -181,7 +181,7 @@
     {
       "name": "calories",
       "amount": 675.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     }
   ]
 }

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__roasted-red-pepper-chicken-pasta.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__roasted-red-pepper-chicken-pasta.json
@@ -102,7 +102,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.99998
+      "confidence": 0.999982
     },
     {
       "input": "1/2 cup extra-virgin olive oil",
@@ -111,7 +111,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999967
+      "confidence": 0.99999
     },
     {
       "input": "2 tablespoons fruity champagne or wine vinegar",
@@ -120,7 +120,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999971
+      "confidence": 0.999959
     },
     {
       "input": "2 teaspoons honey",
@@ -129,7 +129,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999896
+      "confidence": 0.999957
     },
     {
       "input": "2 teaspoons smoked paprika",
@@ -138,7 +138,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999954
+      "confidence": 0.999956
     },
     {
       "input": "1/2-1 teaspoon cayenne pepper",
@@ -165,7 +165,7 @@
       "unit": "teaspoon",
       "comment": "((see note))",
       "other": "",
-      "confidence": 0.999982
+      "confidence": 0.999981
     },
     {
       "input": "red pepper flakes",
@@ -218,7 +218,7 @@
     {
       "name": "calories",
       "amount": 590.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     }
   ]
 }

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__stove-top-mac-and-cheese.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__stove-top-mac-and-cheese.json
@@ -83,7 +83,7 @@
       "unit": "ounce",
       "comment": "cubed",
       "other": "",
-      "confidence": 0.999499
+      "confidence": 0.99989
     },
     {
       "input": "1 medium zucchini, grated ((about 1 cup grated))",
@@ -110,7 +110,7 @@
       "unit": "cup",
       "comment": "shredded",
       "other": "",
-      "confidence": 0.999944
+      "confidence": 0.999822
     },
     {
       "input": "1 cup shredded monterey jack cheese",
@@ -160,7 +160,7 @@
     {
       "input": "1-2 tablespoons salted butter ((optional))",
       "name": "salted butter",
-      "qty": 1.5,
+      "qty": 1.0,
       "unit": "tablespoon",
       "comment": "((optional))",
       "other": "",
@@ -181,7 +181,7 @@
     {
       "name": "calories",
       "amount": 507.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     }
   ]
 }

--- a/tests/endpoint/snapshots/www.hellofresh.com__uk-balsamic-streak-with-red-cabb-5841a8ad9df18165854cdd72.json
+++ b/tests/endpoint/snapshots/www.hellofresh.com__uk-balsamic-streak-with-red-cabb-5841a8ad9df18165854cdd72.json
@@ -214,7 +214,7 @@
     {
       "name": "calories",
       "amount": 535.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "fatContent",

--- a/tests/endpoint/snapshots/www.recipetineats.com__greek-chicken-gyros-with-tzatziki.json
+++ b/tests/endpoint/snapshots/www.recipetineats.com__greek-chicken-gyros-with-tzatziki.json
@@ -261,7 +261,7 @@
       "unit": "cup",
       "comment": "(, preferably full fat)",
       "other": "",
-      "confidence": 0.999981
+      "confidence": 0.999984
     },
     {
       "input": "1 tbsp lemon juice",
@@ -368,7 +368,7 @@
     {
       "name": "calories",
       "amount": 641.78,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.recipetineats.com__naan-recipe.json
+++ b/tests/endpoint/snapshots/www.recipetineats.com__naan-recipe.json
@@ -174,9 +174,9 @@
       "name": "warm tap water ~",
       "qty": 0.5,
       "unit": "cup",
-      "comment": "40.0 degree Celsius/105.0 degree fahrenheit in temperature",
+      "comment": "105\u00b0F in temperature",
       "other": "",
-      "confidence": 0.999944
+      "confidence": 0.99996
     },
     {
       "input": "1 tbsp white sugar",
@@ -221,7 +221,7 @@
       "unit": "cup",
       "comment": "(, or all-purpose/plain (Note 3))",
       "other": "",
-      "confidence": 0.999932
+      "confidence": 0.999976
     },
     {
       "input": "30g / 2 tbsp ghee or unsalted butter (, melted (Note 4))",
@@ -283,7 +283,7 @@
     {
       "name": "calories",
       "amount": 223.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.seriouseats.com__copycat-chicken-nuggets-with-sweet-n-sour-sauce.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__copycat-chicken-nuggets-with-sweet-n-sour-sauce.json
@@ -102,7 +102,7 @@
       "name": "boneless, skinless chicken thighs",
       "qty": 1.0,
       "unit": "pound",
-      "comment": "cut into 1.0 inch pieces",
+      "comment": "cut into 1 inch pieces",
       "other": "",
       "confidence": 0.999922
     },
@@ -185,7 +185,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999897
+      "confidence": 0.999795
     },
     {
       "input": "2 tablespoons (30ml) water",
@@ -194,7 +194,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999918
+      "confidence": 0.999828
     },
     {
       "input": "5 teaspoons (25ml) distilled white vinegar",
@@ -203,7 +203,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999861
+      "confidence": 0.9997
     },
     {
       "input": "1 1/2 teaspoons (4g) cornstarch",
@@ -212,7 +212,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999851
+      "confidence": 0.999667
     },
     {
       "input": "1 teaspoon (3g) chicken-flavored broth powder, such as Orrington Farms",
@@ -284,7 +284,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999904
+      "confidence": 0.999844
     },
     {
       "input": "2 tablespoons (16g) cornstarch",
@@ -293,7 +293,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999908
+      "confidence": 0.999809
     },
     {
       "input": "1 teaspoon (3g) chicken-flavored broth powder, such as Orrington Farms",
@@ -338,7 +338,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999906
+      "confidence": 0.999797
     }
   ],
   "error": null,
@@ -346,7 +346,7 @@
     {
       "name": "calories",
       "amount": 432.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.seriouseats.com__easy-no-knead-focaccia.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__easy-no-knead-focaccia.json
@@ -76,7 +76,7 @@
       "unit": "gram",
       "comment": "see note",
       "other": "",
-      "confidence": 0.997457
+      "confidence": 0.999596
     },
     {
       "input": "10 grams Diamond Crystal kosher salt (0.4 ounce; 2 1/2 teaspoons); for table salt, use about half as much by volume or the same weight",
@@ -85,7 +85,7 @@
       "unit": "gram",
       "comment": "0.4 ounces, for table salt, use about half as much by volume or the same weight",
       "other": "",
-      "confidence": 0.988154
+      "confidence": 0.997719
     },
     {
       "input": "4 grams instant dry yeast, such as SAF (0.1 ounce; 1/2 packet or 1 rounded teaspoon)",
@@ -94,7 +94,7 @@
       "unit": "gram",
       "comment": "such as SAF (0.1 ounces; 1/2 packets or 1 rounded teaspoons)",
       "other": "",
-      "confidence": 0.99286
+      "confidence": 0.99904
     },
     {
       "input": "400 grams room temperature water (14.1 ounces; 1 1/2 cups plus 3 tablespoons)",
@@ -103,7 +103,7 @@
       "unit": "gram",
       "comment": "",
       "other": "",
-      "confidence": 0.824396
+      "confidence": 0.97241
     },
     {
       "input": "68 grams extra-virgin olive oil (2.4 ounces; 5 tablespoons), divided",
@@ -112,7 +112,7 @@
       "unit": "gram",
       "comment": "divided",
       "other": "",
-      "confidence": 0.998724
+      "confidence": 0.999824
     },
     {
       "input": "Coarse sea salt, such as Maldon or fleur de sel",
@@ -129,7 +129,7 @@
     {
       "name": "calories",
       "amount": 302.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.seriouseats.com__five-minute-grilled-chicken-cutlet-rosemary-garlic-lemon-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__five-minute-grilled-chicken-cutlet-rosemary-garlic-lemon-recipe.json
@@ -79,16 +79,16 @@
       "unit": "tablespoon",
       "comment": "minced",
       "other": "",
-      "confidence": 0.999931
+      "confidence": 0.999943
     },
     {
       "input": "2 tablespoons fresh juice from 2 lemons",
-      "name": "fresh juice, lemons",
+      "name": "fresh juice from lemons",
       "qty": 2.0,
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999879
+      "confidence": 0.999937
     },
     {
       "input": "6 tablespoons extra-virgin olive oil",
@@ -97,7 +97,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999959
+      "confidence": 0.99998
     },
     {
       "input": "Kosher salt and freshly ground black pepper",
@@ -115,7 +115,7 @@
       "unit": "",
       "comment": "cut into 8 cutlets",
       "other": "",
-      "confidence": 0.999768
+      "confidence": 0.999769
     }
   ],
   "error": null,
@@ -123,7 +123,7 @@
     {
       "name": "calories",
       "amount": 419.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.seriouseats.com__ingredient-stovetop-mac-and-cheese-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__ingredient-stovetop-mac-and-cheese-recipe.json
@@ -71,7 +71,7 @@
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999695
+      "confidence": 0.999364
     },
     {
       "input": "Salt",
@@ -89,7 +89,7 @@
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999748
+      "confidence": 0.999455
     },
     {
       "input": "6 ounces (170g) grated mild or medium cheddar cheese, or any good melting cheese, such as Fontina, Gruy\u00e8re, or Jack",
@@ -98,7 +98,7 @@
       "unit": "ounce",
       "comment": "grated",
       "other": "",
-      "confidence": 0.999612
+      "confidence": 0.999277
     }
   ],
   "error": null,
@@ -106,7 +106,7 @@
     {
       "name": "calories",
       "amount": 699.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.seriouseats.com__salmon-burgers-remoulade-fennel-slaw-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__salmon-burgers-remoulade-fennel-slaw-recipe.json
@@ -115,7 +115,7 @@
       "unit": "pound",
       "comment": "very finely chopped by hand",
       "other": "",
-      "confidence": 0.999971
+      "confidence": 0.999988
     },
     {
       "input": "3 tablespoons minced mixed fresh parsley, tarragon, and chives (about 4 teaspoons each minced parsley and chives and 1 teaspoon minced tarragon",
@@ -124,7 +124,7 @@
       "unit": "tablespoon",
       "comment": "minced",
       "other": "",
-      "confidence": 0.997625
+      "confidence": 0.998386
     },
     {
       "input": "1/4 teaspoon ground coriander seed",
@@ -169,7 +169,7 @@
       "unit": "cup",
       "comment": "",
       "other": "",
-      "confidence": 0.999901
+      "confidence": 0.999771
     },
     {
       "input": "1 tablespoon drained brined capers, minced",
@@ -196,7 +196,7 @@
       "unit": "teaspoon",
       "comment": "minced",
       "other": "",
-      "confidence": 0.999551
+      "confidence": 0.999595
     },
     {
       "input": "2 teaspoons fresh juice from 1 lemon (10ml)",
@@ -205,7 +205,7 @@
       "unit": "teaspoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999759
+      "confidence": 0.999898
     },
     {
       "input": "1 teaspoon Dijon mustard (5ml)",
@@ -250,7 +250,7 @@
       "unit": "ounce",
       "comment": "peeled, julienned",
       "other": "",
-      "confidence": 0.999458
+      "confidence": 0.999394
     },
     {
       "input": "1 3/4 ounces shredded radicchio (50g; from 1 small head)",
@@ -259,7 +259,7 @@
       "unit": "ounce",
       "comment": "shredded",
       "other": "",
-      "confidence": 0.999726
+      "confidence": 0.999709
     },
     {
       "input": "1 3/4 ounces fennel (50g; from 1 small head), julienned",
@@ -268,7 +268,7 @@
       "unit": "ounce",
       "comment": "julienned",
       "other": "",
-      "confidence": 0.999883
+      "confidence": 0.999948
     },
     {
       "input": "Extra-virgin olive oil, for drizzling",
@@ -339,7 +339,7 @@
     {
       "name": "calories",
       "amount": 930.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.seriouseats.com__spicy-spring-sicilian-pizza-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__spicy-spring-sicilian-pizza-recipe.json
@@ -110,7 +110,7 @@
       "unit": "gram",
       "comment": "",
       "other": "",
-      "confidence": 0.996433
+      "confidence": 0.996435
     },
     {
       "input": "14g kosher salt (0.5 ounce; about 1 tablespoon); for table salt use same weight or half as much by volume",
@@ -135,9 +135,9 @@
       "name": "extra-virgin olive oil",
       "qty": 20.0,
       "unit": "gram",
-      "comment": "0.7 ounces, plus 40.0 grams (1.4 ounces; 0.25 cups) for the baking pan",
+      "comment": "0.70 ounces, plus 40 grams, 1/4 cups for the baking pan",
       "other": "",
-      "confidence": 0.997596
+      "confidence": 0.997595
     },
     {
       "input": "325g room-temperature water (11.5 ounces; about 1 cup plus 7 tablespoons)",
@@ -146,7 +146,7 @@
       "unit": "gram",
       "comment": "",
       "other": "",
-      "confidence": 0.994216
+      "confidence": 0.994707
     },
     {
       "input": "For the Sauce:",
@@ -191,7 +191,7 @@
       "unit": "teaspoon",
       "comment": "or more to taste",
       "other": "",
-      "confidence": 0.999877
+      "confidence": 0.999857
     },
     {
       "input": "One 28-ounce (800g) can whole peeled tomatoes",
@@ -243,9 +243,9 @@
       "name": "natural-casing pepperoni",
       "qty": 12.0,
       "unit": "ounce",
-      "comment": "cut into 0.125 inch-thick slices",
+      "comment": "cut into 1/8 inch-thick slices",
       "other": "",
-      "confidence": 0.999759
+      "confidence": 0.999537
     },
     {
       "input": "4 ounces (115g) ground Pecorino Romano cheese",
@@ -254,7 +254,7 @@
       "unit": "ounce",
       "comment": "",
       "other": "",
-      "confidence": 0.999695
+      "confidence": 0.999365
     }
   ],
   "error": null,
@@ -262,7 +262,7 @@
     {
       "name": "calories",
       "amount": 777.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.seriouseats.com__the-best-roast-potatoes-ever-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__the-best-roast-potatoes-ever-recipe.json
@@ -95,7 +95,7 @@
       "unit": "pound",
       "comment": "peeled and cut into quarters",
       "other": "",
-      "confidence": 0.999805
+      "confidence": 0.999754
     },
     {
       "input": "5 tablespoons (75ml) extra-virgin olive oil, duck fat, goose fat, or beef fat",
@@ -104,7 +104,7 @@
       "unit": "tablespoon",
       "comment": "",
       "other": "",
-      "confidence": 0.999893
+      "confidence": 0.999803
     },
     {
       "input": "Small handful picked rosemary leaves, finely chopped",
@@ -148,7 +148,7 @@
     {
       "name": "calories",
       "amount": 275.0,
-      "unit": "kilocalorie"
+      "unit": "calorie"
     },
     {
       "name": "carbohydrateContent",

--- a/tests/endpoint/snapshots/www.tasteofhome.com__dutch-oven-bread.json
+++ b/tests/endpoint/snapshots/www.tasteofhome.com__dutch-oven-bread.json
@@ -52,9 +52,9 @@
       "name": "all-purpose flour",
       "qty": 3.0,
       "unit": "cup",
-      "comment": "per",
+      "comment": "per cups",
       "other": "",
-      "confidence": 0.99977
+      "confidence": 0.999625
     },
     {
       "input": "1 teaspoon active dry yeast",
@@ -79,9 +79,9 @@
       "name": "water",
       "qty": 1.5,
       "unit": "cup",
-      "comment": "(72.5 degree angle)",
+      "comment": "(70\u00b0 to 75\u00b0)",
       "other": "",
-      "confidence": 0.999929
+      "confidence": 0.999967
     }
   ],
   "error": null,

--- a/tests/unit/test_parse_ingredients.py
+++ b/tests/unit/test_parse_ingredients.py
@@ -4,42 +4,36 @@ import pytest
 from pytest import mark
 
 from pkg.schema.web import Context
-from pkg.services.parser.nlp_parser import list_to_parsed_ingredients, normalize_ingredient
+from pkg.services.parser.nlp_parser import canonicalize_unit, list_to_parsed_ingredients
 
 
 @mark.parametrize(
-    "input,expect",
+    "surface,expect",
     [
-        ("1 tbsp. olive oil", "1 tablespoon olive oil"),
-        ("2 tsp salt", "2 teaspoon salt"),
-        ("3 cups flour", "3.0 cup flour"),
-        ("4 oz. chicken breast", "4.0 ounce chicken breast"),
-        ("5 cloves garlic, minced", "5 cloves garlic, minced"),
-        ("6 slices whole wheat bread", "6 slices whole wheat bread"),
-        ("7 grams sugar", "7.0 gram sugar"),
-        ("8 fl. oz. milk", "8.0 fluid ounce milk"),
-        ("9 lbs. beef", "9.0 pound beef"),
-        ("10 ml vanilla extract", "10.0 milliliter vanilla extract"),
-        ("10 ml", "10.0 milliliter"),
-        ("1/2 cup chopped onions", "0.5 cup chopped onions"),
-        ("3 1/2 cups diced tomatoes", "3.5 cup diced tomatoes"),
-        ("2-3 tablespoons soy sauce", "2 1/2 tablespoon soy sauce"),
-        ("1-1/2 cups water", "1.5 cup water"),
-        ("2-1/4 cups almond flour", "2.25 cup almond flour"),
-        # a stray trailing "/" from quantulum3 must not be consumed (regression:
-        # this used to be non-deterministic across hash seeds)
-        ("30g / 2 tbsp ghee or unsalted butter", "30.0 gram / 2 tablespoon ghee or unsalted butter"),
-        ("1 to 2 teaspoons cayenne pepper", "1 1/2 teaspoon cayenne pepper"),
-        ("1 ½ teaspoons ground black pepper", "1 1/2 teaspoon ground black pepper"),
-        ("1 C parmesan cheese", "1.0 cup parmesan cheese"),
-        (
-            "¾ tsp. Diamond Crystal or ½ tsp. Morton kosher salt, plus more",
-            "3/4 teaspoon Diamond Crystal or 1/2 teaspoon Morton kosher salt, plus more",
-        ),
+        ("Tablespoons", "tablespoon"),
+        ("Tbsp", "tablespoon"),
+        ("Tbsp.", "tablespoon"),
+        ("tbsp", "tablespoon"),
+        ("tsp", "teaspoon"),
+        ("cups", "cup"),
+        ("grams", "gram"),
+        ("g", "gram"),
+        ("oz", "ounce"),
+        ("lbs", "pound"),
+        ("ml", "milliliter"),
+        # already-canonical (pint) names pass through unchanged
+        ("tablespoon", "tablespoon"),
+        ("gram", "gram"),
+        # count units and unknowns are preserved verbatim (quantulum never
+        # canonicalised these either, so we don't gratuitously singularise them)
+        ("cloves", "cloves"),
+        ("slices", "slices"),
+        ("dash", "dash"),
+        ("", ""),
     ],
 )
-def test_normalize_ingredeint(input: str, expect: str) -> None:
-    assert normalize_ingredient(input) == expect
+def test_canonicalize_unit(surface: str, expect: str) -> None:
+    assert canonicalize_unit(surface) == expect
 
 
 @dataclass
@@ -58,7 +52,7 @@ class IngredientCase:
         IngredientCase("0.5 teaspoons salt", 0.5, "teaspoon", "salt", ""),
         IngredientCase("2 1/4 cups almond flour", 2.25, "cup", "almond flour", ""),
         IngredientCase("½ cup all-purpose flour", 0.5, "cup", "all-purpose flour", ""),
-        IngredientCase("1 ½ teaspoons ground black pepper", 1.5, "teaspoon", "black pepper", "ground"),
+        IngredientCase("1 ½ teaspoons ground black pepper", 1.5, "teaspoon", "black pepper", "ground"),
         IngredientCase("⅔ cup unsweetened flaked coconut", 0.667, "cup", "unsweetened flaked coconut", ""),
         IngredientCase("⅓ cup panko bread crumbs", 0.333, "cup", "panko bread crumbs", ""),
         IngredientCase("1/8 cup all-purpose flour", 0.125, "cup", "all-purpose flour", ""),

--- a/tests/unit/test_scraper_parser.py
+++ b/tests/unit/test_scraper_parser.py
@@ -1,0 +1,24 @@
+import pathlib
+
+from recipe_scrapers import scrape_html
+
+# importing the service module applies the lxml parser patch
+import pkg.services.recipes.scraper  # noqa: F401
+
+_HTML = (
+    pathlib.Path(__file__).resolve().parent.parent
+    / "endpoint"
+    / "testdata"
+    / "sallysbakingaddiction.com__spinach-bacon-breakfast-strata.html"
+).read_text()
+
+
+def test_scraper_uses_lxml_not_html_parser() -> None:
+    """Guard the perf patch: the main page soup must be built with lxml, not the
+    hardcoded pure-Python html.parser. If recipe_scrapers changes such that the
+    patch stops taking effect, scraping still works but we lose the speedup —
+    this test catches that silently regressing."""
+    scraper = scrape_html(_HTML, org_url="https://example.com", online=False, supported_only=False)
+    assert scraper.soup.builder.NAME == "lxml"
+    # sanity: extraction still works
+    assert scraper.title()

--- a/tests/unit/test_slim_extruct.py
+++ b/tests/unit/test_slim_extruct.py
@@ -1,0 +1,31 @@
+import sys
+
+# importing pkg runs slim_extruct() (see pkg/__init__.py)
+import pkg  # noqa: F401
+from pkg.services.recipes.scraper import scrape_html, to_schema_data
+
+
+def test_heavy_extruct_extractors_are_not_imported() -> None:
+    """recipe_scrapers only asks extruct for json-ld + microdata, so the
+    microformat (mf2py) and RDFa (pyRdfa -> rdflib) extractors must never load.
+    Guards the ~16 MiB floor saving against a regression."""
+    assert sys.modules.get("extruct.microformat", None) is not None
+    assert getattr(sys.modules["extruct.microformat"], "__extruct_stub__", False) is True
+    assert getattr(sys.modules["extruct.rdfa"], "__extruct_stub__", False) is True
+    for heavy in ("mf2py", "rdflib", "pyRdfa"):
+        assert heavy not in sys.modules, f"{heavy} should not be imported"
+
+
+def test_scraping_still_works_with_slim_extruct() -> None:
+    scraper = scrape_html(
+        "<html><head><script type='application/ld+json'>"
+        '{"@context":"https://schema.org","@type":"Recipe","name":"Test",'
+        '"recipeIngredient":["1 cup flour","2 eggs"]}'
+        "</script></head><body></body></html>",
+        org_url="https://example.com",
+        online=False,
+        supported_only=False,
+    )
+    data = to_schema_data(scraper)
+    assert data.get("name") == "Test"
+    assert len(data.get("ingredients", [])) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -120,12 +120,6 @@ wheels = [
 ]
 
 [[package]]
-name = "docopt"
-version = "0.6.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
-
-[[package]]
 name = "extruct"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -257,19 +251,6 @@ wheels = [
 ]
 
 [[package]]
-name = "inflect"
-version = "7.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "more-itertools" },
-    { name = "typeguard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/78/c6/943357d44a21fd995723d07ccaddd78023eace03c1846049a2645d4324a3/inflect-7.5.0.tar.gz", hash = "sha256:faf19801c3742ed5a05a8ce388e0d8fe1a07f8d095c82201eb904f5d27ad571f", size = 73751, upload-time = "2024-12-28T17:11:18.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/eb/427ed2b20a38a4ee29f24dbe4ae2dafab198674fe9a85e3d6adf9e5f5f41/inflect-7.5.0-py3-none-any.whl", hash = "sha256:2aea70e5e70c35d8350b8097396ec155ffd68def678c7ff97f51aa69c1d92344", size = 35197, upload-time = "2024-12-28T17:11:15.931Z" },
-]
-
-[[package]]
 name = "ingredient-parser-nlp"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -387,15 +368,6 @@ wheels = [
 ]
 
 [[package]]
-name = "more-itertools"
-version = "11.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
-]
-
-[[package]]
 name = "nltk"
 version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -409,18 +381,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
-]
-
-[[package]]
-name = "num2words"
-version = "0.5.14"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docopt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/58/ad645bd38b4b648eb2fc2ba1b909398e54eb0cbb6a7dbd2b4953e38c9621/num2words-0.5.14.tar.gz", hash = "sha256:b066ec18e56b6616a3b38086b5747daafbaa8868b226a36127e0451c0cf379c6", size = 218213, upload-time = "2024-12-17T20:17:10.191Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/5b/545e9267a1cc080c8a1be2746113a063e34bcdd0f5173fd665a5c13cb234/num2words-0.5.14-py3-none-any.whl", hash = "sha256:1c8e5b00142fc2966fd8d685001e36c4a9911e070d1b120e1beb721fa1edb33d", size = 163525, upload-time = "2024-12-17T20:17:06.074Z" },
 ]
 
 [[package]]
@@ -622,29 +582,6 @@ wheels = [
 ]
 
 [[package]]
-name = "quantulum3"
-version = "0.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "inflect" },
-    { name = "num2words" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/e1/02d7c122ec0f13b5ce15c40cd258b504f6c1660047997c8c37b939d9efaf/quantulum3-0.10.0.tar.gz", hash = "sha256:c0367f18745e51d67a65cb3fb1f48a45c8280090ec2d49b11d1a9ee496951946", size = 10638096, upload-time = "2026-03-09T22:27:14.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/d8/357d75783fba9b107863b6408a0ba99bb1cbbb6b750e8c084fb0b838ff81/quantulum3-0.10.0-py3-none-any.whl", hash = "sha256:9084c309dc4f978e06af33811b3f65f61b93c2a178fa8e9777efd5cecf483368", size = 10653420, upload-time = "2026-03-09T22:27:11.728Z" },
-]
-
-[package.optional-dependencies]
-classifier = [
-    { name = "joblib" },
-    { name = "numpy" },
-    { name = "scikit-learn" },
-    { name = "scipy" },
-    { name = "stemming" },
-    { name = "wikipedia" },
-]
-
-[[package]]
 name = "rdflib"
 version = "7.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -680,9 +617,7 @@ dependencies = [
     { name = "ingredient-parser-nlp" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "quantulum3", extra = ["classifier"] },
     { name = "recipe-scrapers" },
-    { name = "scikit-learn" },
     { name = "uvicorn" },
 ]
 
@@ -700,9 +635,7 @@ requires-dist = [
     { name = "ingredient-parser-nlp", specifier = "==2.7.0" },
     { name = "pydantic", specifier = "==2.13.4" },
     { name = "pydantic-settings", specifier = "==2.14.2" },
-    { name = "quantulum3", extras = ["classifier"], specifier = "==0.10.0" },
     { name = "recipe-scrapers", specifier = "==15.11.0" },
-    { name = "scikit-learn", specifier = "==1.8.0" },
     { name = "uvicorn", specifier = "==0.51.0" },
 ]
 
@@ -794,63 +727,6 @@ wheels = [
 ]
 
 [[package]]
-name = "scikit-learn"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "joblib" },
-    { name = "numpy" },
-    { name = "scipy" },
-    { name = "threadpoolctl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
-    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
-    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
-    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
-    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
-    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
-]
-
-[[package]]
-name = "scipy"
-version = "1.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
-    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
-    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
-    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
-    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
-    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
-    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -881,21 +757,6 @@ wheels = [
 ]
 
 [[package]]
-name = "stemming"
-version = "1.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d1/eb/fd53fb51b83a4e3b8e98cfec2fa9e4b99401fce5177ec346e4a5c61df71e/stemming-1.0.1.tar.gz", hash = "sha256:59678702e1d06caffecee82910f048edf12ad89dcf430776b4b05bfb8850bc51", size = 10954, upload-time = "2010-12-20T18:07:34.972Z" }
-
-[[package]]
-name = "threadpoolctl"
-version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.68.4"
 source = { registry = "https://pypi.org/simple" }
@@ -905,18 +766,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/5f/57ff8b434839e70dab45601284ea413e947a63799891b7553e5960a793a8/tqdm-4.68.4.tar.gz", hash = "sha256:19829c9673638f2a0b8617da4cdcb927e831cd88bcfcb6e78d42a4d1af131520", size = 792418, upload-time = "2026-07-07T09:58:18.369Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/2a/5e5e750890ada51017d18d0d4c30da696e5b5bd3180947729927628fc3cb/tqdm-4.68.4-py3-none-any.whl", hash = "sha256:5168118b2368f48c561afda8020fd79195b1bdb0bdf8086b88442c267a315dc2", size = 676612, upload-time = "2026-07-07T09:58:16.256Z" },
-]
-
-[[package]]
-name = "typeguard"
-version = "4.5.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240, upload-time = "2026-05-14T12:59:40.857Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748, upload-time = "2026-05-14T12:59:39.473Z" },
 ]
 
 [[package]]
@@ -979,13 +828,3 @@ sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda5308
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
 ]
-
-[[package]]
-name = "wikipedia"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/67/35/25e68fbc99e672127cc6fbb14b8ec1ba3dfef035bf1e4c90f78f24a80b7d/wikipedia-1.4.0.tar.gz", hash = "sha256:db0fad1829fdd441b1852306e9856398204dc0786d2996dd2e0c8bb8e26133b2", size = 27748, upload-time = "2014-11-15T15:59:49.808Z" }


### PR DESCRIPTION
## Why

Production runs on a **1 GB RAM host with 537 MB swap** (7 containers). The recipes-api process carries a large resident working set dominated by ML/parsing libraries; on that host the kernel swaps it out when idle and pages it back in on access, which is the "spikes that take a while to come down" pattern in the memory graph (confirmed: 7-day max CPU 0.43% while memory swings 15→190 MB — impossible for request-driven allocation).

All numbers below are measured on the production Linux image (Python 3.14, ingredient-parser v2).

## Changes

**1. Replace quantulum3 with deterministic parsing.** quantulum3 pulled in scikit-learn + scipy (never used by the CRF parse), cost ~half the per-line latency, and corrupted ~1 in 7 ingredient lines (`1 plum tomato` → `atomic mass units metre tomato`; prices bleeding into names). Replaced with a deterministic unit-alias canonicaliser and a regex nutrition parser.
- warm memory floor **320 → 231 MiB**; 12-line recipe **21.4 → 9.3 ms** (2.3×); image content **543 → 372 MB**.
- Also fixes two latent pre-processing bugs quantulum had masked (multiple unicode fractions per line; the `1/2"` inch-mark fraction-token leak).

**2. Cap glibc arenas (`MALLOC_ARENA_MAX=2`).** Sync endpoints run across uvicorn's threadpool; uncapped, glibc gives each thread its own arena and freed memory fragments across them, ballooning RSS under load. Pure env change, no code.
- 8-thread retained-under-load **190 → 119 MiB**, peak **408 → 334 MiB**.

**3. Parse scraped HTML with lxml instead of `html.parser`.** recipe_scrapers hardcodes the pure-Python `BeautifulSoup("html.parser")` (top allocator in the memray profile, ~2.2 GB churn). Patched to use lxml.
- scrape 15–28% faster on typical docs; html.parser churn eliminated; **output byte-identical** (all endpoint snapshots pass unchanged).

**4. Skip extruct's unused microformat/RDFa extractors.** extruct eagerly imports mf2py + rdflib + pyRdfa, but recipe_scrapers only requests json-ld + microdata. Stub the unused extractors before extruct loads.
- **~5–6 MiB** off the resident floor, and silences the mf2py DeprecationWarnings. No behaviour change (the disabled syntaxes were never requested).

## Behaviour changes (intentional)

- Ranges (`2-3 tbsp`) now return the **low bound** (2) instead of quantulum's midpoint (2.5).
- Nutrition energy unit is now **`calorie`** (was `kilocalorie`).
- These were audited across all 54 real recipe fixtures: 86 ingredient lines changed, **all fixes or lateral, zero regressions**; a labeled 621-line format-matrix scored 100% qty/unit vs 98.6% before, with 0 regressions.

## Testing

- `mi test` — **164 pass** (added unit tests for the unit canonicaliser, nutrition, the lxml patch, and the extruct slimming).
- `mi lint` — clean.
- **Live API validation** against the running production image: 26/26 endpoint checks pass, and all 54 recipe fixtures scrape with **0 errors** (2 return empty — pre-existing, identical on `main`).

## Net effect on the production symptom

The ~137 MiB working set that was thrashing on the 1 GB host is now **~90 MiB smaller**, with per-thread arena fragmentation capped so load spikes stay bounded — much less to swap in and out on the constrained host.
