### PR TITLE
feat: report ingredient section headings on scraped recipes

### DIFF
--- a/pkg/services/cleaner/cleaner.py
+++ b/pkg/services/cleaner/cleaner.py
@@ -32,6 +32,7 @@ def clean(recipe_data: dict, url=None) -> dict:
         dict: cleaned recipe dictionary
     """
     raw_instructions = recipe_data.get("recipeInstructions", [])
+    ingredients = clean_ingredients(recipe_data.get("recipeIngredient", []))
 
     recipe_copy = {
         "name": clean_string(recipe_data.get("name", "")),
@@ -44,7 +45,8 @@ def clean(recipe_data: dict, url=None) -> dict:
         "keywords": clean_category_like(recipe_data.get("keywords", [])),
         "recipeCategory": clean_category_like(recipe_data.get("recipeCategory", None)),
         "recipeYield": clean_yield(recipe_data.get("recipeYield")),
-        "recipeIngredient": clean_ingredients(recipe_data.get("recipeIngredient", [])),
+        "recipeIngredient": ingredients,
+        "recipeIngredientSections": clean_ingredient_sections(recipe_data.get("recipeIngredientGroups"), ingredients),
         "recipeInstructions": clean_instructions(raw_instructions),
         "recipeInstructionSections": clean_instruction_sections(raw_instructions),
         "images": clean_image(recipe_data.get("image")),
@@ -126,6 +128,49 @@ def clean_image(image: str | list | dict | None = None, default: str = "no image
             return [image]
         case _:
             raise TypeError(f"Unexpected type for image: {type(image)}, {image}")
+
+
+def clean_ingredient_sections(groups: list | None, ingredients: list[str]) -> list[dict] | None:
+    """
+    Map scraper ingredient groups onto index ranges over the cleaned ingredient list.
+
+    Membership is positional, never matched on text: group members come from the page
+    markup and `recipeIngredient` from schema.org, so the two disagree on whitespace and
+    bracketing ("((Note 1))" vs "(Note 1)"). Concatenating the groups in order does
+    reproduce the flat list. A count mismatch means that no longer holds, so the grouping
+    is dropped rather than filed under the wrong heading.
+
+    Returns:
+        list[dict] | None: Sections of name plus member indexes into `ingredients`, or
+        None if there is no usable grouping.
+    """
+    if not groups or not isinstance(groups, list):
+        return None
+
+    sections = []
+    offset = 0
+
+    for group in groups:
+        if not isinstance(group, dict):
+            return None
+
+        members = group.get("ingredients") or []
+        if not members:
+            continue
+
+        name = clean_string(group.get("purpose") or "")
+        sections.append(
+            {
+                "name": name or None,
+                "ingredientIndexes": list(range(offset, offset + len(members))),
+            }
+        )
+        offset += len(members)
+
+    if offset != len(ingredients):
+        return None
+
+    return sections if any(section["name"] for section in sections) else None
 
 
 def clean_instruction_sections(steps_object: list | dict | str | None) -> list[dict] | None:

--- a/pkg/services/cleaner/cleaner.py
+++ b/pkg/services/cleaner/cleaner.py
@@ -136,9 +136,10 @@ def clean_ingredient_sections(groups: list | None, ingredients: list[str]) -> li
 
     Membership is positional, never matched on text: group members come from the page
     markup and `recipeIngredient` from schema.org, so the two disagree on whitespace and
-    bracketing ("((Note 1))" vs "(Note 1)"). Concatenating the groups in order does
-    reproduce the flat list. A count mismatch means that no longer holds, so the grouping
-    is dropped rather than filed under the wrong heading.
+    bracketing ("((Note 1))" vs "(Note 1)"). This assumes the groups partition the flat
+    list in order, which the caller is responsible for establishing — the count check here
+    is a cheap necessary condition only, catching lists of different lengths but not a
+    reordering within an equal-length one.
 
     Returns:
         list[dict] | None: Sections of name plus member indexes into `ingredients`, or

--- a/pkg/services/recipes/recipe.py
+++ b/pkg/services/recipes/recipe.py
@@ -13,6 +13,15 @@ class InstructionSection(BaseModel):
     steps: list[InstructionStep]
 
 
+class IngredientSection(BaseModel):
+    name: str | None = None
+    ingredient_indexes: list[int] = Field(
+        default_factory=list,
+        alias="ingredientIndexes",
+    )
+    """Positions in `Recipe.ingredients` that belong to this section."""
+
+
 class Author(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -62,6 +71,10 @@ class Recipe(BaseModel):
     ingredients: list[str] = Field(
         default_factory=list,
         alias="recipeIngredient",
+    )
+    ingredient_sections: list[IngredientSection] | None = Field(
+        default=None,
+        alias="recipeIngredientSections",
     )
 
     recipeCuisine: str | None = None

--- a/pkg/services/recipes/recipe.py
+++ b/pkg/services/recipes/recipe.py
@@ -18,8 +18,8 @@ class IngredientSection(BaseModel):
     ingredient_indexes: list[int] = Field(
         default_factory=list,
         alias="ingredientIndexes",
+        description="Positions in the recipe's flat ingredient list that belong to this section.",
     )
-    """Positions in `Recipe.ingredients` that belong to this section."""
 
 
 class Author(BaseModel):

--- a/pkg/services/recipes/scraper.py
+++ b/pkg/services/recipes/scraper.py
@@ -57,6 +57,21 @@ def try_get(fn, default=None):
         return default
 
 
+def to_ingredient_groups(scraper: AbstractScraper) -> list[dict[str, Any]] | None:
+    """Capture the scraper's ingredient grouping, if the page actually has one.
+
+    Group headings ("For the Sauce") exist only in the page markup, not in the schema.org
+    data. Recipes without headings still yield a single unnamed group, so a grouping is
+    only worth keeping once at least one group is named.
+    """
+    groups = try_get(scraper.ingredient_groups, [])
+
+    if not groups or not any(group.purpose for group in groups):
+        return None
+
+    return [{"purpose": group.purpose, "ingredients": group.ingredients} for group in groups]
+
+
 def to_schema_data(scraper: AbstractScraper) -> dict[str, Any]:
     if scraper.schema.data and isinstance(scraper.schema.data, dict):
         scraper.schema.data["@content"] = "schema"
@@ -64,6 +79,10 @@ def to_schema_data(scraper: AbstractScraper) -> dict[str, Any]:
         maybeIngredients = try_get(scraper.ingredients, [])
         if len(maybeIngredients) > 0:
             scraper.schema.data["ingredients"] = maybeIngredients
+
+        maybeGroups = to_ingredient_groups(scraper)
+        if maybeGroups:
+            scraper.schema.data["recipeIngredientGroups"] = maybeGroups
 
         maybeInstructions = try_get(scraper.instructions_list, [])
         if len(maybeInstructions) > 0:
@@ -78,6 +97,7 @@ def to_schema_data(scraper: AbstractScraper) -> dict[str, Any]:
         "description": try_get(scraper.description, ""),
         "image": try_get(scraper.image, ""),
         "ingredients": try_get(scraper.ingredients, []),
+        "recipeIngredientGroups": to_ingredient_groups(scraper),
         "instructions": try_get(scraper.instructions_list, []),
         "totalTime": str(try_get(scraper.total_time, "")),
         "prepTime": str(try_get(scraper.prep_time, "")),

--- a/pkg/services/recipes/scraper.py
+++ b/pkg/services/recipes/scraper.py
@@ -63,10 +63,22 @@ def to_ingredient_groups(scraper: AbstractScraper) -> list[dict[str, Any]] | Non
     Group headings ("For the Sauce") exist only in the page markup, not in the schema.org
     data. Recipes without headings still yield a single unnamed group, so a grouping is
     only worth keeping once at least one group is named.
+
+    Downstream membership is positional, so a grouping is only usable if concatenating it
+    reproduces the flat ingredient list in order. `group_ingredients` buckets by heading
+    text, so a heading repeated non-adjacently (or one whose text normalizes to empty,
+    which collapses into the leading unnamed bucket) merges into its first occurrence and
+    silently reorders the result while preserving its length. Comparing against
+    `scraper.ingredients()` catches that: group members are literal elements of that list
+    rather than re-extracted text, so equality is exact here in a way it could never be
+    against schema.org's differently-spelled copy.
     """
     groups = try_get(scraper.ingredient_groups, [])
 
     if not groups or not any(group.purpose for group in groups):
+        return None
+
+    if [ingredient for group in groups for ingredient in group.ingredients] != try_get(scraper.ingredients, []):
         return None
 
     return [{"purpose": group.purpose, "ingredients": group.ingredients} for group in groups]

--- a/pkg/services/recipes/scraper.py
+++ b/pkg/services/recipes/scraper.py
@@ -109,7 +109,6 @@ def to_schema_data(scraper: AbstractScraper) -> dict[str, Any]:
         "description": try_get(scraper.description, ""),
         "image": try_get(scraper.image, ""),
         "ingredients": try_get(scraper.ingredients, []),
-        "recipeIngredientGroups": to_ingredient_groups(scraper),
         "instructions": try_get(scraper.instructions_list, []),
         "totalTime": str(try_get(scraper.total_time, "")),
         "prepTime": str(try_get(scraper.prep_time, "")),

--- a/tests/endpoint/snapshots/cooking.nytimes.com__1015819-chocolate-chip-cookies.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__1015819-chocolate-chip-cookies.json
@@ -33,6 +33,7 @@
       "1 1/4 pounds bittersweet chocolate disks or f\u00e8ves, at least 60 percent cacao content (see note)",
       "Sea salt"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Dessert"

--- a/tests/endpoint/snapshots/cooking.nytimes.com__1023460-challah-bread.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__1023460-challah-bread.json
@@ -64,6 +64,28 @@
       "11 grams kosher salt (about 1 tablespoon Diamond Crystal or 1\u00bd teaspoons Morton coarse kosher salt)",
       "Poppy or sesame seeds, for sprinkling (optional)"
     ],
+    "recipeIngredientSections": [
+      {
+        "name": "For the Preferment",
+        "ingredientIndexes": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "For the Dough",
+        "ingredientIndexes": [
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ]
+      }
+    ],
     "recipeCuisine": null,
     "recipeCategory": [
       "Breads",

--- a/tests/endpoint/snapshots/cooking.nytimes.com__4735-old-fashioned-beef-stew.json
+++ b/tests/endpoint/snapshots/cooking.nytimes.com__4735-old-fashioned-beef-stew.json
@@ -30,6 +30,7 @@
       "2 large baking potatoes, peeled and cut into 3/4-inch cubes",
       "2 teaspoons salt"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Dinner",

--- a/tests/endpoint/snapshots/delightbaking.com__little-fluffy-dinner-rolls.json
+++ b/tests/endpoint/snapshots/delightbaking.com__little-fluffy-dinner-rolls.json
@@ -15,6 +15,7 @@
       "75 g Butter",
       "2x Eggs (medium)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Breakfast",

--- a/tests/endpoint/snapshots/food52.com__65940-gingerbread-dough-for-houses.json
+++ b/tests/endpoint/snapshots/food52.com__65940-gingerbread-dough-for-houses.json
@@ -45,6 +45,7 @@
       "1 1/2 teaspoons baking soda (6 g)",
       "3/4 teaspoon fine sea salt (3 g)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Dessert"

--- a/tests/endpoint/snapshots/leelalicious.com__earl-grey-tea-cake.json
+++ b/tests/endpoint/snapshots/leelalicious.com__earl-grey-tea-cake.json
@@ -50,6 +50,32 @@
       "1/4 cup hot water",
       "3 tablespoons lemon juice"
     ],
+    "recipeIngredientSections": [
+      {
+        "name": null,
+        "ingredientIndexes": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ]
+      },
+      {
+        "name": "Syrup:",
+        "ingredientIndexes": [
+          10,
+          11,
+          12,
+          13
+        ]
+      }
+    ],
     "recipeCuisine": "American",
     "recipeCategory": [
       "Dessert",

--- a/tests/endpoint/snapshots/pinchofyum.com__spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw.json
+++ b/tests/endpoint/snapshots/pinchofyum.com__spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw.json
@@ -1,0 +1,330 @@
+{
+  "url": "https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw",
+  "data": {
+    "name": "Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw",
+    "url": "https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw",
+    "description": "The BEST Shrimp Tacos with Garlic Cilantro Lime Slaw - ready in about 30 minutes and loaded with flavor and texture. SO YUM!",
+    "recipeInstructions": [
+      {
+        "text": "Pulse all the sauce ingredients in a food processor or blender until mostly smooth. Add water if needed to thin."
+      },
+      {
+        "text": "Toss some of the sauce (not all) with the cabbage. We\u2019ll use the leftover sauce to top the tacos."
+      },
+      {
+        "text": "Pat the shrimp dry with paper towels. Toss the shrimp in a small bowl with the spice mix to get it coated. Heat a drizzle of oil a large skillet over medium high heat. Add the shrimp to the hot pan and saut\u00e9 for 5-8 minutes, flipping occasionally, until the shrimp are cooked through."
+      },
+      {
+        "text": "For the prettiest and easiest-to-eat assembly, go in this order: smashed avocado, slaw, and shrimp. Finish with Cotjia cheese, lime wedges, and extra sauce."
+      }
+    ],
+    "recipeInstructionSections": null,
+    "recipeIngredient": [
+      "1/4 cup oil",
+      "1/2 cup chopped green onions",
+      "1/2 cup cilantro leaves",
+      "2 cloves garlic",
+      "1/2 teaspoon salt",
+      "juice of 2 limes",
+      "1/2 cup sour cream or full-fat Greek yogurt",
+      "1/4 cup water (if needed, to thin sauce)",
+      "2 teaspoons each chili powder and cumin",
+      "1/2 teaspoon each onion powder and garlic powder",
+      "1/4 teaspoon cayenne pepper (more or less to taste)",
+      "1 teaspoon coarse sea salt",
+      "1 lb. large shrimp, peeled and deveined, tails removed",
+      "2-3 cups shredded green cabbage",
+      "8 small tortillas (corn or flour)",
+      "2 avocados",
+      "1/4 cup Cotija cheese",
+      "lime wedges for serving"
+    ],
+    "recipeIngredientSections": [
+      {
+        "name": "Garlic Cilantro Lime Sauce:",
+        "ingredientIndexes": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ]
+      },
+      {
+        "name": "Shrimp Taco Spice Mix:",
+        "ingredientIndexes": [
+          8,
+          9,
+          10,
+          11
+        ]
+      },
+      {
+        "name": "Stuff for the Shrimp Tacos:",
+        "ingredientIndexes": [
+          12,
+          13,
+          14,
+          15,
+          16,
+          17
+        ]
+      }
+    ],
+    "recipeCuisine": null,
+    "recipeCategory": [
+      "Dinner"
+    ],
+    "keywords": [
+      "Spicy Shrimp Tacos",
+      "Shrimp Taco Recipe",
+      "Garlic Lime Slaw"
+    ],
+    "images": [
+      "https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw-Square.jpg?fit=225%2C225",
+      "https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw-Square.jpg?fit=195%2C195",
+      "https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw-Square.jpg?fit=180%2C180",
+      "https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw-Square.jpg"
+    ],
+    "recipeYield": "4 (2 small tacos each)",
+    "prepTime": "20 Minutes",
+    "performTime": null,
+    "cookTime": "10 Minutes",
+    "totalTime": "30 Minutes",
+    "dateModified": null,
+    "datePublished": "2022-06-24",
+    "nutrition": {
+      "calories": "426 calories",
+      "sugarContent": "3.4 g",
+      "sodiumContent": "930.4 mg",
+      "fatContent": "21.7 g",
+      "saturatedFatContent": "4.3 g",
+      "transFatContent": "0.3 g",
+      "carbohydrateContent": "34.5 g",
+      "fiberContent": "5.3 g",
+      "proteinContent": "27.9 g",
+      "cholesterolContent": "199.4 mg",
+      "@type": "nutritionInformation"
+    }
+  },
+  "ingredients": [
+    {
+      "input": "1/4 cup oil",
+      "name": "oil",
+      "qty": 0.25,
+      "unit": "cup",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999886
+    },
+    {
+      "input": "1/2 cup chopped green onions",
+      "name": "green onions",
+      "qty": 0.5,
+      "unit": "cup",
+      "comment": "chopped",
+      "other": "",
+      "confidence": 0.999854
+    },
+    {
+      "input": "1/2 cup cilantro leaves",
+      "name": "cilantro leaves",
+      "qty": 0.5,
+      "unit": "cup",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999989
+    },
+    {
+      "input": "2 cloves garlic",
+      "name": "garlic",
+      "qty": 2.0,
+      "unit": "cloves",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999259
+    },
+    {
+      "input": "1/2 teaspoon salt",
+      "name": "salt",
+      "qty": 0.5,
+      "unit": "teaspoon",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999849
+    },
+    {
+      "input": "juice of 2 limes",
+      "name": "limes",
+      "qty": 2.0,
+      "unit": "",
+      "comment": "juice of",
+      "other": "",
+      "confidence": 0.982295
+    },
+    {
+      "input": "1/2 cup sour cream or full-fat Greek yogurt",
+      "name": "sour cream, full-fat Greek yogurt",
+      "qty": 0.5,
+      "unit": "cup",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999966
+    },
+    {
+      "input": "1/4 cup water (if needed, to thin sauce)",
+      "name": "water",
+      "qty": 0.25,
+      "unit": "cup",
+      "comment": "(if needed, to thin sauce)",
+      "other": "",
+      "confidence": 0.999798
+    },
+    {
+      "input": "2 teaspoons each chili powder and cumin",
+      "name": "chili powder, cumin",
+      "qty": 2.0,
+      "unit": "teaspoon",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999781
+    },
+    {
+      "input": "1/2 teaspoon each onion powder and garlic powder",
+      "name": "onion powder, garlic powder",
+      "qty": 0.5,
+      "unit": "teaspoon",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999849
+    },
+    {
+      "input": "1/4 teaspoon cayenne pepper (more or less to taste)",
+      "name": "cayenne pepper",
+      "qty": 0.25,
+      "unit": "teaspoon",
+      "comment": "(more or less to taste)",
+      "other": "",
+      "confidence": 0.999936
+    },
+    {
+      "input": "1 teaspoon coarse sea salt",
+      "name": "coarse sea salt",
+      "qty": 1.0,
+      "unit": "teaspoon",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999931
+    },
+    {
+      "input": "1 lb. large shrimp, peeled and deveined, tails removed",
+      "name": "shrimp",
+      "qty": 1.0,
+      "unit": "pound",
+      "comment": "peeled and deveined, tails removed",
+      "other": "",
+      "confidence": 0.99988
+    },
+    {
+      "input": "2-3 cups shredded green cabbage",
+      "name": "green cabbage",
+      "qty": 2.0,
+      "unit": "cup",
+      "comment": "shredded",
+      "other": "",
+      "confidence": 0.999703
+    },
+    {
+      "input": "8 small tortillas (corn or flour)",
+      "name": "tortillas",
+      "qty": 8.0,
+      "unit": "",
+      "comment": "(corn or flour)",
+      "other": "",
+      "confidence": 0.998957
+    },
+    {
+      "input": "2 avocados",
+      "name": "avocados",
+      "qty": 2.0,
+      "unit": "",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999871
+    },
+    {
+      "input": "1/4 cup Cotija cheese",
+      "name": "Cotija cheese",
+      "qty": 0.25,
+      "unit": "cup",
+      "comment": "",
+      "other": "",
+      "confidence": 0.999987
+    },
+    {
+      "input": "lime wedges for serving",
+      "name": "lime wedges",
+      "qty": 1.0,
+      "unit": "",
+      "comment": "",
+      "other": "",
+      "confidence": 0.0
+    }
+  ],
+  "error": null,
+  "nutrition": [
+    {
+      "name": "calories",
+      "amount": 426.0,
+      "unit": "calorie"
+    },
+    {
+      "name": "sugarContent",
+      "amount": 3.4,
+      "unit": "gram"
+    },
+    {
+      "name": "sodiumContent",
+      "amount": 930.4,
+      "unit": "milligram"
+    },
+    {
+      "name": "fatContent",
+      "amount": 21.7,
+      "unit": "gram"
+    },
+    {
+      "name": "saturatedFatContent",
+      "amount": 4.3,
+      "unit": "gram"
+    },
+    {
+      "name": "transFatContent",
+      "amount": 0.3,
+      "unit": "gram"
+    },
+    {
+      "name": "carbohydrateContent",
+      "amount": 34.5,
+      "unit": "gram"
+    },
+    {
+      "name": "fiberContent",
+      "amount": 5.3,
+      "unit": "gram"
+    },
+    {
+      "name": "proteinContent",
+      "amount": 27.9,
+      "unit": "gram"
+    },
+    {
+      "name": "cholesterolContent",
+      "amount": 199.4,
+      "unit": "milligram"
+    }
+  ]
+}

--- a/tests/endpoint/snapshots/preppykitchen.com__chocolate-chip-banana-bread.json
+++ b/tests/endpoint/snapshots/preppykitchen.com__chocolate-chip-banana-bread.json
@@ -40,6 +40,7 @@
       "3 very ripe bananas (mashed (1 1/2 cups))",
       "1 cup semi-sweet chocolate chips ((180g))"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Breakfast",

--- a/tests/endpoint/snapshots/prettysimplesweet.com__chocolate-buns-2.json
+++ b/tests/endpoint/snapshots/prettysimplesweet.com__chocolate-buns-2.json
@@ -39,6 +39,7 @@
       "1/2 stick ((55g) unsalted butter, cubed and softened to room temperature)",
       "2/3 cup (100-120g) chocolate chips or chunks"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [],

--- a/tests/endpoint/snapshots/sallysbakingaddiction.com__spinach-bacon-breakfast-strata.json
+++ b/tests/endpoint/snapshots/sallysbakingaddiction.com__spinach-bacon-breakfast-strata.json
@@ -51,6 +51,7 @@
       "1/4 teaspoon fresh ground black pepper",
       "optional garnish: fresh ground black pepper, flaky sea salt, and/or extra parmesan cheese"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Breakfast"

--- a/tests/endpoint/snapshots/thedomesticrebel.com__levain-bakery-style-ultimate-peanut-butter-cookies.json
+++ b/tests/endpoint/snapshots/thedomesticrebel.com__levain-bakery-style-ultimate-peanut-butter-cookies.json
@@ -37,6 +37,7 @@
       "2 cups peanut butter chips",
       "1\u00bd cups Reese's Pieces candies"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Cookies",

--- a/tests/endpoint/snapshots/themodernproper.com__thai-basil-beef.json
+++ b/tests/endpoint/snapshots/themodernproper.com__thai-basil-beef.json
@@ -36,6 +36,30 @@
       "1 tbsp brown sugar",
       "2 tbsp fresh lime juice"
     ],
+    "recipeIngredientSections": [
+      {
+        "name": null,
+        "ingredientIndexes": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "name": "Thai Basil Beef Sauce",
+        "ingredientIndexes": [
+          7,
+          8,
+          9,
+          10,
+          11
+        ]
+      }
+    ],
     "recipeCuisine": null,
     "recipeCategory": [
       "Dinner",

--- a/tests/endpoint/snapshots/therecipecritic.com__crispy-parmesan-garlic-chicken-zucchini.json
+++ b/tests/endpoint/snapshots/therecipecritic.com__crispy-parmesan-garlic-chicken-zucchini.json
@@ -25,6 +25,7 @@
       "2 medium zucchini (sliced)",
       "2 garlic cloves (minced)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Dinner",

--- a/tests/endpoint/snapshots/www.bonappetit.com__adult-mac-and-cheese.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__adult-mac-and-cheese.json
@@ -39,6 +39,7 @@
       "1 cup whole milk",
       "5 oz. store-bought grated Parmesan"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.bonappetit.com__best-pumpkin-pie.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__best-pumpkin-pie.json
@@ -33,6 +33,7 @@
       "2 tsp. vanilla extract",
       "Whipped cream (for serving)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.bonappetit.com__cabbage-roll-casserole.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__cabbage-roll-casserole.json
@@ -54,6 +54,7 @@
       "8 oz. cr\u00e8me fra\u00eeche",
       "8 oz. low-moisture mozzarella"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.bonappetit.com__cheesesteaks.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__cheesesteaks.json
@@ -43,6 +43,7 @@
       "10 ounces mild or sharp provolone slices (about 16)",
       "Ketchup and/or hot sauce (for serving; optional)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.bonappetit.com__chicken-scarpariello.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__chicken-scarpariello.json
@@ -38,6 +38,7 @@
       "3 sprigs rosemary",
       "Chopped parsley (for serving)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.bonappetit.com__easiest-chicken-adobo.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__easiest-chicken-adobo.json
@@ -43,6 +43,7 @@
       "Freshly ground black pepper",
       "1 cup uncooked white rice, preferably short grain"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.bonappetit.com__grilled-chicken-tacos.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__grilled-chicken-tacos.json
@@ -26,6 +26,7 @@
       "Charred Tomatillo Salsa Verde (click for recipe; for serving)",
       "Cilantro sprigs, sliced radishes, and lime wedges (for serving)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.bonappetit.com__mama-rosas-lasagna-de-carne.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__mama-rosas-lasagna-de-carne.json
@@ -49,6 +49,7 @@
       "Freshly ground black pepper",
       "12 oz. low-moisture mozzarella, coarsely grated (about 3 cups)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.bonappetit.com__roasted-broccoli.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__roasted-broccoli.json
@@ -15,6 +15,7 @@
       "5 Tbsp. olive oil",
       "Kosher salt, freshly ground black pepper"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.bonappetit.com__seafood-chowder.json
+++ b/tests/endpoint/snapshots/www.bonappetit.com__seafood-chowder.json
@@ -34,6 +34,7 @@
       "1 Tbsp. all-purpose flour",
       "\u00bd cup half-and-half"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.budgetbytes.com__beef-cabbage-stir-fry.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__beef-cabbage-stir-fry.json
@@ -35,6 +35,37 @@
       "1 Tbsp sesame seeds ($0.08)",
       "1 Tbsp sriracha ($0.05)"
     ],
+    "recipeIngredientSections": [
+      {
+        "name": "STIR FRY SAUCE",
+        "ingredientIndexes": [
+          0,
+          1,
+          2,
+          3
+        ]
+      },
+      {
+        "name": "STIR FRY",
+        "ingredientIndexes": [
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11
+        ]
+      },
+      {
+        "name": "GARNISHES (optional)",
+        "ingredientIndexes": [
+          12,
+          13
+        ]
+      }
+    ],
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [],

--- a/tests/endpoint/snapshots/www.budgetbytes.com__easy-pesto-chicken-and-vegetables.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__easy-pesto-chicken-and-vegetables.json
@@ -41,6 +41,7 @@
       "1/8 tsp freshly cracked pepper* ($0.01)",
       "1 Tbsp grated Parmesan* ($0.11)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Dinner",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__fried-cabbage-and-noodles.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__fried-cabbage-and-noodles.json
@@ -30,6 +30,7 @@
       "2 Tbsp butter ($0.20)",
       "salt and pepper to taste ($0.05)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Dinner",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__one-pot-creamy-cajun-chicken-pasta.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__one-pot-creamy-cajun-chicken-pasta.json
@@ -44,6 +44,35 @@
       "2 oz. cream cheese ($0.50)",
       "3 green onions, sliced ($0.25)"
     ],
+    "recipeIngredientSections": [
+      {
+        "name": "Cajun Seasoning",
+        "ingredientIndexes": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ]
+      },
+      {
+        "name": "Chicken Pasta",
+        "ingredientIndexes": [
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ]
+      }
+    ],
     "recipeCuisine": "American",
     "recipeCategory": [
       "Dinner",

--- a/tests/endpoint/snapshots/www.budgetbytes.com__unstuffed-bell-peppers.json
+++ b/tests/endpoint/snapshots/www.budgetbytes.com__unstuffed-bell-peppers.json
@@ -48,6 +48,7 @@
       "1 cup shredded mozzarella ($0.85)",
       "1 Tbsp chopped parsley (optional garnish) ($0.05)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Dinner",

--- a/tests/endpoint/snapshots/www.cookingchanneltv.com__baked-potato-fries-reloaded-5470330.json
+++ b/tests/endpoint/snapshots/www.cookingchanneltv.com__baked-potato-fries-reloaded-5470330.json
@@ -33,6 +33,7 @@
       "Fry/candy thermometer",
       "Large hand strainer or \"spider\""
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.delish.com__creamy-tuscan-chicken-recipe.json
+++ b/tests/endpoint/snapshots/www.delish.com__creamy-tuscan-chicken-recipe.json
@@ -33,6 +33,7 @@
       "1/4 c. freshly grated Parmesan",
       "Lemon wedges, for serving"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Low-Cost",

--- a/tests/endpoint/snapshots/www.ethanchlebowski.com__grams-buns-the-greatest-bread-roll.json
+++ b/tests/endpoint/snapshots/www.ethanchlebowski.com__grams-buns-the-greatest-bread-roll.json
@@ -31,6 +31,7 @@
       "56 g softened butter",
       "1 whole egg, beaten"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [],

--- a/tests/endpoint/snapshots/www.ethanchlebowski.com__kolaches-sweet-amp-savory.json
+++ b/tests/endpoint/snapshots/www.ethanchlebowski.com__kolaches-sweet-amp-savory.json
@@ -7,6 +7,7 @@
     "recipeInstructions": [],
     "recipeInstructionSections": null,
     "recipeIngredient": [],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [],

--- a/tests/endpoint/snapshots/www.foodnetwork.com__baked-macaroni-and-cheese-recipe-1939524.json
+++ b/tests/endpoint/snapshots/www.foodnetwork.com__baked-macaroni-and-cheese-recipe-1939524.json
@@ -41,6 +41,7 @@
       "3 tablespoons butter",
       "1 cup panko bread crumbs"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Side-Dish"

--- a/tests/endpoint/snapshots/www.foodnetwork.com__instant-pancake-mix-recipe-1938544.json
+++ b/tests/endpoint/snapshots/www.foodnetwork.com__instant-pancake-mix-recipe-1938544.json
@@ -47,6 +47,7 @@
       "1 stick butter, for greasing the pan",
       "2 cups fresh fruit such as blueberries, if desired"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__brown-butter-oatmeal-chocolate-chip-cookies.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__brown-butter-oatmeal-chocolate-chip-cookies.json
@@ -22,6 +22,7 @@
       "2 cups chocolate chunks or chips",
       "flaky sea salt, for sprinkling ((optional))"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Cookies",

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__chicken-gyros-with-feta-tzatziki.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__chicken-gyros-with-feta-tzatziki.json
@@ -30,6 +30,36 @@
       "1-2 Persian cucumbers, shredded",
       "kosher salt"
     ],
+    "recipeIngredientSections": [
+      {
+        "name": null,
+        "ingredientIndexes": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11
+        ]
+      },
+      {
+        "name": "Feta Tzatziki",
+        "ingredientIndexes": [
+          12,
+          13,
+          14,
+          15,
+          16,
+          17
+        ]
+      }
+    ],
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [],

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__chili-crisp-peanut-noodles.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__chili-crisp-peanut-noodles.json
@@ -29,6 +29,7 @@
       "3 tablespoons chopped peanuts",
       "2 tablespoons lime juice"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Main Course"

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__creamy-parmesan-chicken-and-spinach-tortellini.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__creamy-parmesan-chicken-and-spinach-tortellini.json
@@ -29,6 +29,7 @@
       "1/2 cup grated parmesan cheese",
       "juice from 1 lemon"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [],

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__green-chile-chicken.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__green-chile-chicken.json
@@ -24,6 +24,7 @@
       "1 jar salsa verde",
       "fresh cilantro and limes for serving"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Main Course"

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__korean-beef-sesame-noodles.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__korean-beef-sesame-noodles.json
@@ -26,6 +26,32 @@
       "1/4 cup toasted sesame seeds",
       "1/2 cup fresh basil"
     ],
+    "recipeIngredientSections": [
+      {
+        "name": "Sauce",
+        "ingredientIndexes": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ]
+      },
+      {
+        "name": "Stir Fry",
+        "ingredientIndexes": [
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13
+        ]
+      }
+    ],
     "recipeCuisine": null,
     "recipeCategory": [
       "Main Course"

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__one-pot-hamburger-helper.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__one-pot-hamburger-helper.json
@@ -26,6 +26,7 @@
       "1 tablespoon ketchup",
       "fresh parsley, for serving"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [],

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__roasted-red-pepper-chicken-pasta.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__roasted-red-pepper-chicken-pasta.json
@@ -29,6 +29,7 @@
       "1 cup fresh basil, chopped",
       "1 cup arugula"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Main Course"

--- a/tests/endpoint/snapshots/www.halfbakedharvest.com__stove-top-mac-and-cheese.json
+++ b/tests/endpoint/snapshots/www.halfbakedharvest.com__stove-top-mac-and-cheese.json
@@ -26,6 +26,7 @@
       "1-2 tablespoons salted butter ((optional))",
       "Kosher salt and black pepper"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [],

--- a/tests/endpoint/snapshots/www.hellofresh.com__uk-balsamic-streak-with-red-cabb-5841a8ad9df18165854cdd72.json
+++ b/tests/endpoint/snapshots/www.hellofresh.com__uk-balsamic-streak-with-red-cabb-5841a8ad9df18165854cdd72.json
@@ -42,6 +42,7 @@
       "1 tablespoon Vegetable Oil",
       "1 teaspoon Sugar"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Main Course"

--- a/tests/endpoint/snapshots/www.joshuaweissman.com__best-mac-and-cheese-recipe.json
+++ b/tests/endpoint/snapshots/www.joshuaweissman.com__best-mac-and-cheese-recipe.json
@@ -7,6 +7,7 @@
     "recipeInstructions": [],
     "recipeInstructionSections": null,
     "recipeIngredient": [],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [
       "Entree"

--- a/tests/endpoint/snapshots/www.recipetineats.com__greek-chicken-gyros-with-tzatziki.json
+++ b/tests/endpoint/snapshots/www.recipetineats.com__greek-chicken-gyros-with-tzatziki.json
@@ -123,6 +123,55 @@
       "Salt and pepper",
       "4 to 6 pita breads or flat breads"
     ],
+    "recipeIngredientSections": [
+      {
+        "name": null,
+        "ingredientIndexes": [
+          0
+        ]
+      },
+      {
+        "name": "Marinade",
+        "ingredientIndexes": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ]
+      },
+      {
+        "name": "Tzatziki",
+        "ingredientIndexes": [
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15
+        ]
+      },
+      {
+        "name": "Salad",
+        "ingredientIndexes": [
+          16,
+          17,
+          18,
+          19,
+          20
+        ]
+      },
+      {
+        "name": "To Serve",
+        "ingredientIndexes": [
+          21
+        ]
+      }
+    ],
     "recipeCuisine": "Greek",
     "recipeCategory": [
       "Dinner",

--- a/tests/endpoint/snapshots/www.recipetineats.com__naan-recipe.json
+++ b/tests/endpoint/snapshots/www.recipetineats.com__naan-recipe.json
@@ -123,6 +123,36 @@
       "Coriander/cilantro (, finely chopped)",
       "Shredded cheese ((for cheese naan) \u2013 Monterey Jack, cheddar, tasty, colby, anything that melts (shred yourself) (Note 6))"
     ],
+    "recipeIngredientSections": [
+      {
+        "name": null,
+        "ingredientIndexes": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7
+        ]
+      },
+      {
+        "name": "Finishes:",
+        "ingredientIndexes": [
+          8,
+          9,
+          10,
+          11
+        ]
+      },
+      {
+        "name": "Cheese Naan:",
+        "ingredientIndexes": [
+          12
+        ]
+      }
+    ],
     "recipeCuisine": "Indian",
     "recipeCategory": [
       "Breads",

--- a/tests/endpoint/snapshots/www.seriouseats.com__copycat-chicken-nuggets-with-sweet-n-sour-sauce.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__copycat-chicken-nuggets-with-sweet-n-sour-sauce.json
@@ -55,6 +55,7 @@
       "3/4 cup (180ml) water",
       "4 cups (950ml) vegetable oil, for frying"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Appetizers And Hors D'Oeuvres",

--- a/tests/endpoint/snapshots/www.seriouseats.com__easy-no-knead-focaccia.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__easy-no-knead-focaccia.json
@@ -36,6 +36,7 @@
       "68 grams extra-virgin olive oil (2.4 ounces; 5 tablespoons), divided",
       "Coarse sea salt, such as Maldon or fleur de sel"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "Italian",
     "recipeCategory": [
       "Bread",

--- a/tests/endpoint/snapshots/www.seriouseats.com__five-minute-grilled-chicken-cutlet-rosemary-garlic-lemon-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__five-minute-grilled-chicken-cutlet-rosemary-garlic-lemon-recipe.json
@@ -24,6 +24,7 @@
       "Kosher salt and freshly ground black pepper",
       "4 boneless, skinless chicken breasts (5 to 7 ounces each), cut into 8 cutlets"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Entree",

--- a/tests/endpoint/snapshots/www.seriouseats.com__ingredient-stovetop-mac-and-cheese-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__ingredient-stovetop-mac-and-cheese-recipe.json
@@ -19,6 +19,7 @@
       "6 ounces (180ml) evaporated milk",
       "6 ounces (170g) grated mild or medium cheddar cheese, or any good melting cheese, such as Fontina, Gruy\u00e8re, or Jack"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Mains",

--- a/tests/endpoint/snapshots/www.seriouseats.com__salmon-burgers-remoulade-fennel-slaw-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__salmon-burgers-remoulade-fennel-slaw-recipe.json
@@ -56,6 +56,7 @@
       "1/4 cup vegetable oil (60ml)",
       "4 brioche hamburger buns, buttered and toasted"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Entree",

--- a/tests/endpoint/snapshots/www.seriouseats.com__spicy-spring-sicilian-pizza-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__spicy-spring-sicilian-pizza-recipe.json
@@ -51,6 +51,7 @@
       "12 ounces (325g) natural-casing pepperoni, cut into 1/8-inch-thick slices",
       "4 ounces (115g) ground Pecorino Romano cheese"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "Italian",
     "recipeCategory": [
       "Mains",

--- a/tests/endpoint/snapshots/www.seriouseats.com__the-best-roast-potatoes-ever-recipe.json
+++ b/tests/endpoint/snapshots/www.seriouseats.com__the-best-roast-potatoes-ever-recipe.json
@@ -32,6 +32,7 @@
       "Freshly ground black pepper",
       "Small handful fresh parsley leaves, minced"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": "American",
     "recipeCategory": [
       "Side Dish",

--- a/tests/endpoint/snapshots/www.tasteofhome.com__dutch-oven-bread.json
+++ b/tests/endpoint/snapshots/www.tasteofhome.com__dutch-oven-bread.json
@@ -22,6 +22,7 @@
       "1 teaspoon salt",
       "1-1/2 cups water (70\u00b0 to 75\u00b0)"
     ],
+    "recipeIngredientSections": null,
     "recipeCuisine": null,
     "recipeCategory": [],
     "keywords": [],

--- a/tests/endpoint/test_parser_snapshots.py
+++ b/tests/endpoint/test_parser_snapshots.py
@@ -111,6 +111,8 @@ def test_parse_clean(client: TestClient, url: str, name: str) -> None:
         assert i.text == j.text
 
     assert recipe.ingredients == expect_recipe.ingredients
+    assert recipe.ingredient_sections == expect_recipe.ingredient_sections
+    assert recipe.instruction_sections == expect_recipe.instruction_sections
     assert recipe.category == expect_recipe.category
 
     assert recipe.keywords == expect_recipe.keywords

--- a/tests/endpoint/testdata/pinchofyum.com__spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw.html
+++ b/tests/endpoint/testdata/pinchofyum.com__spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw.html
@@ -1,0 +1,3320 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="profile" href="http://gmpg.org/xfn/11">
+<link rel="pingback" href="https://pinchofyum.com/xmlrpc.php">
+
+	<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests;block-all-mixed-content">
+
+<link rel="dns-prefetch" href="//www.googletagmanager.com" />
+<script>
+window.dataLayer = window.dataLayer || [];
+
+	dataLayer.push({
+	'publishedDate': "2022-06-24",
+	'modifiedDate': "2026-01-05",
+});
+
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-WZ4GRNV');
+</script>
+
+<meta property="fb:admins" content="110900202" />
+
+<script>
+/* Font Face Observer v2.1.0 - © Bram Stein. License: BSD-3-Clause */(function(){function l(a,b){document.addEventListener?a.addEventListener("scroll",b,!1):a.attachEvent("scroll",b)}function m(a){document.body?a():document.addEventListener?document.addEventListener("DOMContentLoaded",function c(){document.removeEventListener("DOMContentLoaded",c);a()}):document.attachEvent("onreadystatechange",function k(){if("interactive"==document.readyState||"complete"==document.readyState)document.detachEvent("onreadystatechange",k),a()})};function t(a){this.a=document.createElement("div");this.a.setAttribute("aria-hidden","true");this.a.appendChild(document.createTextNode(a));this.b=document.createElement("span");this.c=document.createElement("span");this.h=document.createElement("span");this.f=document.createElement("span");this.g=-1;this.b.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";this.c.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";
+this.f.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";this.h.style.cssText="display:inline-block;width:200%;height:200%;font-size:16px;max-width:none;";this.b.appendChild(this.h);this.c.appendChild(this.f);this.a.appendChild(this.b);this.a.appendChild(this.c)}
+function u(a,b){a.a.style.cssText="max-width:none;min-width:20px;min-height:20px;display:inline-block;overflow:hidden;position:absolute;width:auto;margin:0;padding:0;top:-999px;white-space:nowrap;font-synthesis:none;font:"+b+";"}function z(a){var b=a.a.offsetWidth,c=b+100;a.f.style.width=c+"px";a.c.scrollLeft=c;a.b.scrollLeft=a.b.scrollWidth+100;return a.g!==b?(a.g=b,!0):!1}function A(a,b){function c(){var a=k;z(a)&&a.a.parentNode&&b(a.g)}var k=a;l(a.b,c);l(a.c,c);z(a)};function B(a,b){var c=b||{};this.family=a;this.style=c.style||"normal";this.weight=c.weight||"normal";this.stretch=c.stretch||"normal"}var C=null,D=null,E=null,F=null;function G(){if(null===D)if(J()&&/Apple/.test(window.navigator.vendor)){var a=/AppleWebKit\/([0-9]+)(?:\.([0-9]+))(?:\.([0-9]+))/.exec(window.navigator.userAgent);D=!!a&&603>parseInt(a[1],10)}else D=!1;return D}function J(){null===F&&(F=!!document.fonts);return F}
+function K(){if(null===E){var a=document.createElement("div");try{a.style.font="condensed 100px sans-serif"}catch(b){}E=""!==a.style.font}return E}function L(a,b){return[a.style,a.weight,K()?a.stretch:"","100px",b].join(" ")}
+B.prototype.load=function(a,b){var c=this,k=a||"BESbswy",r=0,n=b||3E3,H=(new Date).getTime();return new Promise(function(a,b){if(J()&&!G()){var M=new Promise(function(a,b){function e(){(new Date).getTime()-H>=n?b(Error(""+n+"ms timeout exceeded")):document.fonts.load(L(c,'"'+c.family+'"'),k).then(function(c){1<=c.length?a():setTimeout(e,25)},b)}e()}),N=new Promise(function(a,c){r=setTimeout(function(){c(Error(""+n+"ms timeout exceeded"))},n)});Promise.race([N,M]).then(function(){clearTimeout(r);a(c)},
+b)}else m(function(){function v(){var b;if(b=-1!=f&&-1!=g||-1!=f&&-1!=h||-1!=g&&-1!=h)(b=f!=g&&f!=h&&g!=h)||(null===C&&(b=/AppleWebKit\/([0-9]+)(?:\.([0-9]+))/.exec(window.navigator.userAgent),C=!!b&&(536>parseInt(b[1],10)||536===parseInt(b[1],10)&&11>=parseInt(b[2],10))),b=C&&(f==w&&g==w&&h==w||f==x&&g==x&&h==x||f==y&&g==y&&h==y)),b=!b;b&&(d.parentNode&&d.parentNode.removeChild(d),clearTimeout(r),a(c))}function I(){if((new Date).getTime()-H>=n)d.parentNode&&d.parentNode.removeChild(d),b(Error(""+
+n+"ms timeout exceeded"));else{var a=document.hidden;if(!0===a||void 0===a)f=e.a.offsetWidth,g=p.a.offsetWidth,h=q.a.offsetWidth,v();r=setTimeout(I,50)}}var e=new t(k),p=new t(k),q=new t(k),f=-1,g=-1,h=-1,w=-1,x=-1,y=-1,d=document.createElement("div");d.dir="ltr";u(e,L(c,"sans-serif"));u(p,L(c,"serif"));u(q,L(c,"monospace"));d.appendChild(e.a);d.appendChild(p.a);d.appendChild(q.a);document.body.appendChild(d);w=e.a.offsetWidth;x=p.a.offsetWidth;y=q.a.offsetWidth;I();A(e,function(a){f=a;v()});u(e,
+L(c,'"'+c.family+'",sans-serif'));A(p,function(a){g=a;v()});u(p,L(c,'"'+c.family+'",serif'));A(q,function(a){h=a;v()});u(q,L(c,'"'+c.family+'",monospace'))})})};"object"===typeof module?module.exports=B:(window.FontFaceObserver=B,window.FontFaceObserver.prototype.load=B.prototype.load);}());
+</script>
+
+<style>
+.w-7 {
+	width: 1.75rem;
+}
+
+.w-8 {
+	width: 2rem;
+}
+
+.w-9 {
+	width: 2.25rem;
+}
+
+.w-10 {
+	width: 2.5rem;
+}
+
+
+.search-form {
+	position: relative
+}
+
+.search-form label {
+	display: block;
+	height: 1.25rem;
+	margin-left: .75rem;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 1.25rem
+}
+
+.search-form input {
+	--tw-shadow: inset 0 4px 0 1px rgba(0, 0, 0, .075);
+	--tw-shadow-colored: inset 0 4px 0 1px var(--tw-shadow-color);
+	-webkit-appearance: none;
+	border-radius: 0;
+	box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+	height: 50px;
+	padding: .5rem .75rem .5rem 2.5rem
+}
+
+.home-hero .search-form input {
+	--tw-border-opacity: 1;
+	border-color: rgb(153 153 153/var(--tw-border-opacity));
+	border-width: 1px
+}
+</style>
+<style>
+@media(min-width: 640px) {
+    .sm\:-mb-7 {
+        margin-bottom: -1.75rem
+    }
+}
+</style><style>
+.poy-breadcrumb>span>span,
+.poy-breadcrumb>span>span span { display: flex; }
+.poy-breadcrumb a {
+    margin-right: 0.5rem;
+    padding-right: 1rem;
+}
+</style><style>
+.search-form {
+	position: relative
+}
+
+.search-form label {
+	display: block;
+	height: 1.25rem;
+	margin-left: .75rem;
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 1.25rem
+}
+
+.search-form input {
+	--tw-shadow: inset 0 4px 0 1px rgba(0, 0, 0, .075);
+	--tw-shadow-colored: inset 0 4px 0 1px var(--tw-shadow-color);
+	-webkit-appearance: none;
+	border-radius: 0;
+	box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+	height: 50px;
+	padding: .5rem .75rem .5rem 2.5rem
+}
+
+.home-hero .search-form input {
+	--tw-border-opacity: 1;
+	border-color: rgb(153 153 153/var(--tw-border-opacity));
+	border-width: 1px
+}
+</style>
+
+<script data-no-optimize="1" data-cfasync="false">!function(){"use strict";const t={adt_ei:{identityApiKey:"plainText",source:"url",type:"plaintext",priority:1},adt_eih:{identityApiKey:"sha256",source:"urlh",type:"hashed",priority:2},sh_kit:{identityApiKey:"sha256",source:"urlhck",type:"hashed",priority:3}},e=Object.keys(t);function i(t){return function(t){const e=t.match(/((?=([a-z0-9._!#$%+^&*()[\]<>-]+))\2@[a-z0-9._-]+\.[a-z0-9._-]+)/gi);return e?e[0]:""}(function(t){return t.replace(/\s/g,"")}(t.toLowerCase()))}!async function(){const n=new URL(window.location.href),o=n.searchParams;let a=null;const r=Object.entries(t).sort(([,t],[,e])=>t.priority-e.priority).map(([t])=>t);for(const e of r){const n=o.get(e),r=t[e];if(!n||!r)continue;const c=decodeURIComponent(n),d="plaintext"===r.type&&i(c),s="hashed"===r.type&&c;if(d||s){a={value:c,config:r};break}}if(a){const{value:t,config:e}=a;window.adthrive=window.adthrive||{},window.adthrive.cmd=window.adthrive.cmd||[],window.adthrive.cmd.push(function(){window.adthrive.identityApi({source:e.source,[e.identityApiKey]:t},({success:i,data:n})=>{i?window.adthrive.log("info","Plugin","detectEmails",`Identity API called with ${e.type} email: ${t}`,n):window.adthrive.log("warning","Plugin","detectEmails",`Failed to call Identity API with ${e.type} email: ${t}`,n)})})}!function(t,e){const i=new URL(e);t.forEach(t=>i.searchParams.delete(t)),history.replaceState(null,"",i.toString())}(e,n)}()}();
+</script><meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+		<link rel="preconnect" href="https://www.google-analytics.com" />
+					<link rel="preload" href="https://pinchofyum.com/content/assets/fonts/consul-sans750/consul-sans750.woff2" as="font" type="font/woff2" crossorigin>
+					<link rel="preload" href="https://pinchofyum.com/content/assets/fonts/domaine-display/domaine-display-narrow-web-semibold.woff2" as="font" type="font/woff2" crossorigin>
+					<link rel="preload" href="https://pinchofyum.com/content/assets/fonts/bitter/bitter-latin-italic.woff2" as="font" type="font/woff2" crossorigin>
+					<link rel="preload" href="https://pinchofyum.com/content/assets/fonts/arvo/arvo-regular.woff2" as="font" type="font/woff2" crossorigin>
+				<link rel="preload" href="https://pinchofyum.com/content/assets/dist/style.css?r=1784319909" as="style" />
+
+<script data-no-optimize="1" data-cfasync="false">
+(function(w, d) {
+	w.adthrive = w.adthrive || {};
+	w.adthrive.cmd = w.adthrive.cmd || [];
+	w.adthrive.plugin = 'adthrive-ads-3.13.0';
+	w.adthrive.host = 'ads.adthrive.com';
+	w.adthrive.integration = 'plugin';
+
+	var commitParam = (w.adthriveCLS && w.adthriveCLS.bucket !== 'prod' && w.adthriveCLS.branch) ? '&commit=' + w.adthriveCLS.branch : '';
+
+	var s = d.createElement('script');
+	s.async = true;
+	s.referrerpolicy='no-referrer-when-downgrade';
+	s.src = 'https://' + w.adthrive.host + '/sites/5531445f4f3ba0833a7842a4/ads.min.js?referrer=' + w.encodeURIComponent(w.location.href) + commitParam + '&cb=' + (Math.floor(Math.random() * 100) + 1) + '';
+	var n = d.getElementsByTagName('script')[0];
+	n.parentNode.insertBefore(s, n);
+})(window, document);
+</script>
+<link rel="dns-prefetch" href="https://ads.adthrive.com/"><link rel="preconnect" href="https://ads.adthrive.com/"><link rel="preconnect" href="https://ads.adthrive.com/" crossorigin>
+	<!-- This site is optimized with the Yoast SEO Premium plugin v27.9 (Yoast SEO v27.9) - https://yoast.com/product/yoast-seo-premium-wordpress/ -->
+	<title>Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw Recipe - Pinch of Yum</title>
+	<meta name="description" content="Spicy shrimp tacos with creamy garlic cilantro lime slaw, avocado, and Cotija cheese. Quick 30‑minute dinner packed with flavor and texture!" />
+	<link rel="canonical" href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw" />
+	<meta property="og:description" content="THE BEST shrimp tacos loaded with avocado, spicy shrimp, and a homemade creamy lime slaw? HELLO YUMMY!" />
+	<meta property="og:url" content="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw" />
+	<meta property="og:site_name" content="Pinch of Yum" />
+	<meta property="article:publisher" content="https://www.facebook.com/pinchofyum" />
+	<meta property="article:author" content="https://www.facebook.com/pinchofyum" />
+	<meta property="article:published_time" content="2022-06-24T09:00:00+00:00" />
+	<meta property="article:modified_time" content="2026-01-05T18:56:09+00:00" />
+	<meta property="og:image" content="https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw-1200-630.jpg" />
+	<meta property="og:image:width" content="1200" />
+	<meta property="og:image:height" content="630" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="author" content="Lindsay" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:creator" content="@pinchofyum" />
+	<meta name="twitter:site" content="@pinchofyum" />
+	<meta name="twitter:label1" content="Written by" />
+	<meta name="twitter:data1" content="Lindsay" />
+	<meta name="twitter:label2" content="Est. reading time" />
+	<meta name="twitter:data2" content="6 minutes" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https:\/\/schema.org","@graph":[{"@type":"Article","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#article","isPartOf":{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw"},"author":{"name":"Lindsay Ostrom","@id":"https:\/\/pinchofyum.com\/#\/schema\/person\/8d4b17c71f73debc14204a0352749dca"},"headline":"Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw","datePublished":"2022-06-24T09:00:00+00:00","dateModified":"2026-01-05T18:56:09+00:00","wordCount":974,"commentCount":792,"publisher":{"@id":"https:\/\/pinchofyum.com\/#\/schema\/person\/8d4b17c71f73debc14204a0352749dca"},"image":{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#primaryimage"},"thumbnailUrl":"https:\/\/pinchofyum.com\/tachyon\/Easy-Shrimp-Tacos.jpg","articleSection":["All Recipes","Avocado","Dinner","Fish and Seafood","Lime","Lunch","Main Dishes","Most Popular","Quick and Easy","Sugar-Free","Summer","Tacos"],"inLanguage":"en-US","potentialAction":[{"@type":"CommentAction","name":"Comment","target":["https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#respond"]}],"video":[{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#video"}]},{"@type":["WebPage","FAQPage"],"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw","url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw","name":"Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw - Pinch of Yum","isPartOf":{"@id":"https:\/\/pinchofyum.com\/#website"},"primaryImageOfPage":{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#primaryimage"},"image":{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#primaryimage"},"thumbnailUrl":"https:\/\/pinchofyum.com\/tachyon\/Easy-Shrimp-Tacos.jpg","datePublished":"2022-06-24T09:00:00+00:00","dateModified":"2026-01-05T18:56:09+00:00","description":"Spicy shrimp tacos with creamy garlic cilantro lime slaw, avocado, and Cotija cheese. Quick 30‑minute dinner packed with flavor and texture!","breadcrumb":{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#breadcrumb"},"mainEntity":[{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1631739467917"},{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1631739533126"},{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1631739584891"},{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1679513846597"},{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1679513938526"},{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1679513979002"}],"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw"]}]},{"@type":"ImageObject","inLanguage":"en-US","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#primaryimage","url":"https:\/\/pinchofyum.com\/tachyon\/Easy-Shrimp-Tacos.jpg","contentUrl":"https:\/\/pinchofyum.com\/tachyon\/Easy-Shrimp-Tacos.jpg","width":1200,"height":1800,"caption":"Shrimp tacos with sauce."},{"@type":"BreadcrumbList","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Recipes","item":"https:\/\/pinchofyum.com\/recipes"},{"@type":"ListItem","position":2,"name":"Fish and Seafood"}]},{"@type":"WebSite","@id":"https:\/\/pinchofyum.com\/#website","url":"https:\/\/pinchofyum.com\/","name":"Pinch of Yum","description":"A food blog with simple and tasty recipes.","publisher":{"@id":"https:\/\/pinchofyum.com\/#\/schema\/person\/8d4b17c71f73debc14204a0352749dca"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/pinchofyum.com\/?s={search_term_string}"},"query-input":{"@type":"PropertyValueSpecification","valueRequired":true,"valueName":"search_term_string"}}],"inLanguage":"en-US"},{"@type":["Person","Organization"],"@id":"https:\/\/pinchofyum.com\/#\/schema\/person\/8d4b17c71f73debc14204a0352749dca","name":"Lindsay Ostrom","image":{"@type":"ImageObject","inLanguage":"en-US","@id":"https:\/\/pinchofyum.com\/tachyon\/Headshot-Main-Bio-Circle.jpg","url":"https:\/\/pinchofyum.com\/tachyon\/Headshot-Main-Bio-Circle.jpg","contentUrl":"https:\/\/pinchofyum.com\/tachyon\/Headshot-Main-Bio-Circle.jpg","width":1638,"height":1638,"caption":"Lindsay"},"logo":{"@id":"https:\/\/pinchofyum.com\/tachyon\/Headshot-Main-Bio-Circle.jpg"},"description":"A little thing about me: I ♡ FOOD. I used to be a teacher, and now making food and writing about it online is my full-time job. I love talking with people about food, and I'm so glad you're here. Did you make a recipe? Tag @pinchofyum on Instagram so we can find you!","sameAs":["https:\/\/pinchofyum.com","https:\/\/www.facebook.com\/pinchofyum","https:\/\/instagram.com\/pinchofyum","https:\/\/pinterest.com\/pinchofyum","https:\/\/x.com\/pinchofyum"],"url":"https:\/\/pinchofyum.com\/author\/lindsay"},{"@type":"Question","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1631739467917","position":1,"url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1631739467917","name":"Any subs for cilantro? I really don't like the taste.","answerCount":1,"acceptedAnswer":{"@type":"Answer","text":"You could use parsley, but it would definitely lend a different flavor. You can always just omit the cilantro!","inLanguage":"en-US"},"inLanguage":"en-US"},{"@type":"Question","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1631739533126","position":2,"url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1631739533126","name":"How long will the sauce last in the fridge?","answerCount":1,"acceptedAnswer":{"@type":"Answer","text":"3-4 days in a sealed container! ","inLanguage":"en-US"},"inLanguage":"en-US"},{"@type":"Question","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1631739584891","position":3,"url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1631739584891","name":"I can't find cotija cheese. What should I use instead?","answerCount":1,"acceptedAnswer":{"@type":"Answer","text":"You could use another salty crumbled cheese like feta, or just omit! They are just as delicious without cheese.","inLanguage":"en-US"},"inLanguage":"en-US"},{"@type":"Question","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1679513846597","position":4,"url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1679513846597","name":"Any shortcut ideas to make this recipe even easier?","answerCount":1,"acceptedAnswer":{"@type":"Answer","text":"Buy storebought taco seasoning in place of the dried spices, buy shrimp that already peeled\/deveined, and\/or use a similar storebought sauce or dressing for the slaw!","inLanguage":"en-US"},"inLanguage":"en-US"},{"@type":"Question","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1679513938526","position":5,"url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1679513938526","name":"Can I fry the shrimp in this recipe?","answerCount":1,"acceptedAnswer":{"@type":"Answer","text":"Yes! The <a href=\"https:\/\/pinchofyum.com\/crispy-fish-tacos-jalapeno-sauce\" target=\"_blank\" rel=\"noreferrer noopener\">beer batter instructions in this recipe <\/a>work for shrimp, too! ","inLanguage":"en-US"},"inLanguage":"en-US"},{"@type":"Question","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1679513979002","position":6,"url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#faq-question-1679513979002","name":"Could I use a different type of seafood than shrimp?","answerCount":1,"acceptedAnswer":{"@type":"Answer","text":"Sure could! Something simple like cod fillets, halibut, or mahi mahi would work great and have a similar flavor profile. This is my favorite <a href=\"https:\/\/pinchofyum.com\/best-easy-fish-tacos\">easy fish taco recipe<\/a>!","inLanguage":"en-US"},"inLanguage":"en-US"},{"@context":"https:\/\/schema.org\/","@type":"Recipe","name":"Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw","description":"The BEST Shrimp Tacos with Garlic Cilantro Lime Slaw - ready in about 30 minutes and loaded with flavor and texture. SO YUM!","author":{"@type":"Person","name":"Lindsay Ostrom","url":"https:\/\/pinchofyum.com\/about"},"keywords":"spicy shrimp tacos, shrimp taco recipe, garlic lime slaw","image":["https:\/\/pinchofyum.com\/tachyon\/Shrimp-Tacos-with-Slaw-Square.jpg?fit=225%2C225","https:\/\/pinchofyum.com\/tachyon\/Shrimp-Tacos-with-Slaw-Square.jpg?fit=195%2C195","https:\/\/pinchofyum.com\/tachyon\/Shrimp-Tacos-with-Slaw-Square.jpg?fit=180%2C180","https:\/\/pinchofyum.com\/tachyon\/Shrimp-Tacos-with-Slaw-Square.jpg"],"url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw","recipeIngredient":["1\/4 cup oil","1\/2 cup chopped green onions","1\/2 cup cilantro leaves","2 cloves garlic","1\/2 teaspoon salt","juice of 2 limes","1\/2 cup sour cream or full-fat Greek yogurt","1\/4 cup water (if needed, to thin sauce)","2 teaspoons each chili powder and cumin","1\/2 teaspoon each onion powder and garlic powder","1\/4 teaspoon cayenne pepper (more or less to taste)","1 teaspoon coarse sea salt","1 lb. large shrimp, peeled and deveined, tails removed","2-3 cups shredded green cabbage","8 small tortillas (corn or flour)","2 avocados","1\/4 cup Cotija cheese","lime wedges for serving"],"recipeInstructions":[{"@type":"HowToStep","text":"Pulse all the sauce ingredients in a food processor or blender until mostly smooth. Add water if needed to thin.","name":"Sauce","url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#instruction-step-1","video":{"@context":"http:\/\/schema.org","@type":"VideoObject","name":"Spicy Shrimp Tacos Step 1","description":"Pulse all the sauce ingredients in a food processor or blender until mostly smooth.","duration":"PT10S","embedUrl":"https:\/\/player.vimeo.com\/video\/418600899?dnt=1&amp;app_id=122963","contentUrl":"https:\/\/vimeo.com\/418600899","thumbnailUrl":["https:\/\/i.vimeocdn.com\/video\/893223084-491c55e3f9825a63f74cf7952751a862e9e5731a9b26c1749640c4ce4fbeea4a-d_295x166?region=us"],"uploadDate":"2020-05-14T15:49:45+00:00"}},{"@type":"HowToStep","text":"Toss some of the sauce (not all) with the cabbage. We&#8217;ll use the leftover sauce to top the tacos.","name":"Slaw","url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#instruction-step-2","video":{"@context":"http:\/\/schema.org","@type":"VideoObject","name":"Spicy Shrimp Tacos Step 2","description":"Toss some of the sauce (not all) with the cabbage. We'll use the leftover sauce to top the tacos.","duration":"PT10S","embedUrl":"https:\/\/player.vimeo.com\/video\/418601052?dnt=1&amp;app_id=122963","contentUrl":"https:\/\/vimeo.com\/418601052","thumbnailUrl":["https:\/\/i.vimeocdn.com\/video\/893223298-e598b847ae0f15f9435efffb0c7d918beb5c43cf030032dc49c37d151d1bf91f-d_295x166?region=us"],"uploadDate":"2020-05-14T15:50:10+00:00"}},{"@type":"HowToStep","text":"Pat the shrimp dry with paper towels. Toss the shrimp in a small bowl with the spice mix to get it coated. Heat a drizzle of oil a large skillet over medium high heat. Add the shrimp to the hot pan and sauté for 5-8 minutes, flipping occasionally, until the shrimp are cooked through.","name":"Shrimp","url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#instruction-step-3","video":{"@context":"http:\/\/schema.org","@type":"VideoObject","name":"Spicy Shrimp Tacos Step 3","description":"Pat the shrimp dry with paper towels. Toss the shrimp in a small bowl with the spice mix to get it coated. Heat a drizzle of oil a large skillet over medium high heat. Add the shrimp to the hot pan and saute for 5-8 minutes, flipping occasionally, until the shrimp are cooked through.","duration":"PT16S","embedUrl":"https:\/\/player.vimeo.com\/video\/418601228?dnt=1&amp;app_id=122963","contentUrl":"https:\/\/vimeo.com\/418601228","thumbnailUrl":["https:\/\/i.vimeocdn.com\/video\/893223749-3d91df8ab810eb430fc42b2ed17dd88a4f160cf43a009e68a26c3bfe13a59d56-d_295x166?region=us"],"uploadDate":"2020-05-14T15:50:35+00:00"}},{"@type":"HowToStep","text":"For the prettiest and easiest-to-eat assembly, go in this order: smashed avocado, slaw, and shrimp. Finish with Cotjia cheese, lime wedges, and extra sauce.","name":"Assembly","url":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#instruction-step-4","video":{"@context":"http:\/\/schema.org","@type":"VideoObject","name":"Spicy Shrimp Tacos Step 4","description":"For the prettiest and easiest-to-eat assembly, go in this order: smashed avocado, slaw, and shrimp. Finish with Cotjia cheese, lime wedges, and extra sauce.","duration":"PT14S","embedUrl":"https:\/\/player.vimeo.com\/video\/418601483?dnt=1&amp;app_id=122963","contentUrl":"https:\/\/vimeo.com\/418601483","thumbnailUrl":["https:\/\/i.vimeocdn.com\/video\/893223989-e009079233d85b54a9c89e7570e399884e21aa2d672f99216258947d04747db6-d_295x166?region=us"],"uploadDate":"2020-05-14T15:51:11+00:00"}}],"prepTime":"PT20M","cookTime":"PT10M","totalTime":"PT30M","recipeYield":["4","4 (2 small tacos each)"],"recipeCategory":"Dinner","cookingMethod":"Sauté","recipeCuisine":"Mexican","aggregateRating":{"@type":"AggregateRating","reviewCount":"312","ratingValue":"4.8"},"nutrition":{"servingSize":null,"calories":"426 calories","sugarContent":"3.4 g","sodiumContent":"930.4 mg","fatContent":"21.7 g","saturatedFatContent":"4.3 g","transFatContent":"0.3 g","carbohydrateContent":"34.5 g","fiberContent":"5.3 g","proteinContent":"27.9 g","cholesterolContent":"199.4 mg","@type":"nutritionInformation"},"video":{"@context":"http:\/\/schema.org","@type":"VideoObject","name":"Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw","description":"The BEST Shrimp Tacos with Garlic Cilantro Lime Slaw – ready in about 30 minutes and loaded with flavor and texture. SO YUM!","contentUrl":"https:\/\/content.jwplatform.com\/videos\/1uLiMsIQ.mp4","thumbnailUrl":["https:\/\/content.jwplatform.com\/thumbs\/1uLiMsIQ-720.jpg"],"uploadDate":"2021-05-20T15:15:23+00:00"},"review":[{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Becky"},"datePublished":"2023-01-22","reviewBody":"These are incredible! I've made these probably 10-15 times since finding this recipe. In fact, having them again tonight! They're so good!!!"},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Danni"},"datePublished":"2015-04-18","reviewBody":"I would say yes- I made these with shrimp and chicken- absolutely phenomenal and easy. :) \r\nI have to say- these don't seem right with anything battered. So good and healthy without it.\r\nI love this blog. :)"},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Jessica Emerson"},"datePublished":"2020-07-13","reviewBody":"That sauce- gah!  My dad said the meal was \"restaurant quality.\"  Thank you!"},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Ioana Rosenbaum"},"datePublished":"2025-03-16","reviewBody":"I made it several times now our family loves it."},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Lisa"},"datePublished":"2020-01-11","reviewBody":"Oh, my goodness!  This was a fabulous fast &amp; easy dinner.  The sauce really does make the dish.  Creamy but not at all heavy and a perfect counter to the  shrimp.  I didn't have tortillas so I built it on a large bowl of the dressed slaw.  Then I garnished with some tortilla chips.  It's a keeper!!"},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"LaVaya"},"datePublished":"2023-07-20","reviewBody":"Do you need to cook or warm up the corn or flour tortillas before you add the fillings?"},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Missy"},"datePublished":"2016-08-03","reviewBody":"I hope it's ok to pipe in....not that it is a big deal or anything... but I saw this comment when scrolling through, and if I had to guess, I would assume that the directions actually did mean to say to take the tail off the shrimp, not the head, am I correct?? I only say this because I learned an interesting fact a few years ago about why the the vast majority of shrimp sold (and purchased) in stores are shrimps without the heads.  Apparently, if the head is kept on the shrimp for even a couple of hours after it's dead, it will begin to release strong enzymes into the body of the shrimp, which then break down the shrimp flesh and make the shrimp super mushy and yucky, and no one wants that!!! I know this is super irrelevant and unnecessary to respond to a comment a year later, but I figured I would share my knowledge to anyone who wanted to listen lol. Anyways..... thanks for the amazing recipe!!! I was actually also curious where you went in CA that you got these tacos originally, as I live here in So Cal, and just wanted to see if maybe there is a new place I have to go check out for a date night or something =) Thank's again for the great recipe, can't wait to check out more on here =)"},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Marion"},"datePublished":"2017-05-05","reviewBody":"Terry, I think she did mean remove the tails. Some shrimp recipes, mostly fried, specify to leave the tails on. Also, some food photographers prefer to picture the shrimp tails on, even the recipe obviously call for their removal, but doesn't specify. And, Missy, I'd do some research about the dangers of leaving the heads on. My experience says otherwise."},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Ana"},"datePublished":"2019-08-21","reviewBody":"Amazing tacos\r\nThank you!"},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Shannon"},"datePublished":"2022-01-28","reviewBody":"Amazing! Loved everything about this recipe - wouldn’t change a thing. I did substitute feta because the recommended cheese is hard to find here. \r\n\r\nThat sauce is incredible! Will definitely be making these again soon! Thanks for another amazing recipe."},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Devi hayutin"},"datePublished":"2022-12-29","reviewBody":"So good lol"},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"5"},"author":{"@type":"Person","name":"Michaella Clark"},"datePublished":"2021-06-30","reviewBody":"Hi, I am wondering with the leftover cilantro sauce, or if you made double, could you freeze that?"},{"@type":"Review","reviewRating":{"@type":"Rating","ratingValue":"2"},"author":{"@type":"Person","name":"Kelsey"},"datePublished":"2020-06-02","reviewBody":"I made this dish last night and it was disturbingly salty and just... not very good. Never again."}],"datePublished":"2022-06-24","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#recipe","isPartOf":{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#article"},"mainEntityOfPage":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw"},{"@type":"VideoObject","@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#video","name":"Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw - Pinch of Yum","isPartOf":{"@id":"https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#article"},"thumbnailUrl":"https:\/\/pinchofyum.com\/content\/uploads\/Easy-Shrimp-Tacos.jpg","description":"Spicy shrimp tacos with creamy garlic cilantro lime slaw, avocado, and Cotija cheese. Quick 30‑minute dinner packed with flavor and texture!","uploadDate":"2022-06-24T04:00:00+00:00","width":1920,"height":1080,"embedUrl":"https:\/\/player.vimeo.com\/video\/418600899","duration":"PT1M2S","isFamilyFriendly":true,"inLanguage":"en-US"}]}</script>
+	<meta property="og:video" content="https://player.vimeo.com/video/418600899" />
+	<meta property="og:video:type" content="text/html" />
+	<meta property="og:video:duration" content="62" />
+	<meta property="og:video:width" content="1920" />
+	<meta property="og:video:height" content="1080" />
+	<meta property="ya:ovs:adult" content="false" />
+	<meta property="ya:ovs:upload_date" content="2022-06-24T09:00:00+00:00" />
+	<meta property="ya:ovs:allow_embed" content="true" />
+	<!-- / Yoast SEO Premium plugin. -->
+
+
+<link rel="alternate" type="application/rss+xml" title="Pinch of Yum &raquo; Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw Comments Feed" href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw/feed" />
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://pinchofyum.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fpinchofyum.com%2Fspicy-shrimp-tacos-with-garlic-cilantro-lime-slaw" />
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://pinchofyum.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fpinchofyum.com%2Fspicy-shrimp-tacos-with-garlic-cilantro-lime-slaw&#038;format=xml" />
+<style id="classic-theme-styles-inline-css">
+/*! This file is auto-generated */
+.wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
+/*# sourceURL=/wp-includes/css/classic-themes.min.css */
+</style>
+
+<style id="global-styles-inline-css">
+:root{--wp--preset--aspect-ratio--square: 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4: 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3: 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16: 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--color--poy-purple: #734060;--wp--preset--color--poy-gray-400: #f0f0f0;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgb(252,185,0) 0%,rgb(255,105,0) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgb(255,105,0) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0);--wp--preset--shadow--crisp: 6px 6px 0px rgb(0, 0, 0);}:where(body) { margin: 0; }:where(.is-layout-flex){gap: 0.5em;}:where(.is-layout-grid){gap: 0.5em;}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}body{padding-top: 0px;padding-right: 0px;padding-bottom: 0px;padding-left: 0px;}:root :where(.wp-element-button, .wp-block-button__link){background-color: #32373c;border-width: 0;color: #fff;font-family: inherit;font-size: inherit;font-style: inherit;font-weight: inherit;letter-spacing: inherit;line-height: inherit;padding-top: calc(0.667em + 2px);padding-right: calc(1.333em + 2px);padding-bottom: calc(0.667em + 2px);padding-left: calc(1.333em + 2px);text-decoration: none;text-transform: inherit;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-poy-purple-color{color: var(--wp--preset--color--poy-purple) !important;}.has-poy-gray-400-color{color: var(--wp--preset--color--poy-gray-400) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-poy-purple-background-color{background-color: var(--wp--preset--color--poy-purple) !important;}.has-poy-gray-400-background-color{background-color: var(--wp--preset--color--poy-gray-400) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-poy-purple-border-color{border-color: var(--wp--preset--color--poy-purple) !important;}.has-poy-gray-400-border-color{border-color: var(--wp--preset--color--poy-gray-400) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+/*# sourceURL=global-styles-inline-css */
+</style>
+
+<style id="pinchofyum-fonts">
+@font-face{font-display:swap;font-family:Arvo;font-style:normal;font-weight:400;src:url(https://pinchofyum.com/content/assets/fonts/arvo/arvo-regular.woff2) format("woff2")}@font-face{font-display:swap;font-family:Arvo;font-style:normal;font-weight:700;src:url(https://pinchofyum.com/content/assets/fonts/arvo/arvo-latin-700.woff2) format("woff2")}@font-face{font-display:swap;font-family:Bitter;font-style:normal;font-weight:400;src:url(https://pinchofyum.com/content/assets/fonts/bitter/bitter-latin-regular.woff2) format("woff2")}@font-face{font-display:swap;font-family:Bitter;font-style:normal;font-weight:700;src:url(https://pinchofyum.com/content/assets/fonts/bitter/bitter-latin-700.woff2) format("woff2")}@font-face{font-display:swap;font-family:Bitter;font-style:italic;font-weight:400;src:url(https://pinchofyum.com/content/assets/fonts/bitter/bitter-latin-italic.woff2) format("woff2")}@font-face{font-display:swap;font-family:Bitter;font-style:italic;font-weight:700;src:url(https://pinchofyum.com/content/assets/fonts/bitter/bitter-latin-700italic.woff2) format("woff2")}@font-face{font-family:Domaine Display;src:url(https://pinchofyum.com/content/assets/fonts/domaine-display/domaine-display-narrow-web-semibold.woff2) format("woff2")}@font-face{font-display:swap;font-family:Drama Regular;src:url(https://pinchofyum.com/content/assets/fonts/drama-regular-lite/drama-regular-subset.woff2) format("woff2")}@font-face{font-display:swap;font-family:ConsulSans-750;font-style:bold;font-weight:700;src:url(https://pinchofyum.com/content/assets/fonts/consul-sans750/consul-sans750.woff2) format("woff2")}
+</style>
+<style>*,::backdrop,:after,:before{--tw-border-spacing-x:0;--tw-border-spacing-y:0;--tw-translate-x:0;--tw-translate-y:0;--tw-rotate:0;--tw-skew-x:0;--tw-skew-y:0;--tw-scale-x:1;--tw-scale-y:1;--tw-pan-x: ;--tw-pan-y: ;--tw-pinch-zoom: ;--tw-scroll-snap-strictness:proximity;--tw-gradient-from-position: ;--tw-gradient-via-position: ;--tw-gradient-to-position: ;--tw-ordinal: ;--tw-slashed-zero: ;--tw-numeric-figure: ;--tw-numeric-spacing: ;--tw-numeric-fraction: ;--tw-ring-inset: ;--tw-ring-offset-width:0px;--tw-ring-offset-color:#fff;--tw-ring-color:#3b82f680;--tw-ring-offset-shadow:0 0 #0000;--tw-ring-shadow:0 0 #0000;--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;--tw-blur: ;--tw-brightness: ;--tw-contrast: ;--tw-grayscale: ;--tw-hue-rotate: ;--tw-invert: ;--tw-saturate: ;--tw-sepia: ;--tw-drop-shadow: ;--tw-backdrop-blur: ;--tw-backdrop-brightness: ;--tw-backdrop-contrast: ;--tw-backdrop-grayscale: ;--tw-backdrop-hue-rotate: ;--tw-backdrop-invert: ;--tw-backdrop-opacity: ;--tw-backdrop-saturate: ;--tw-backdrop-sepia: ;--tw-contain-size: ;--tw-contain-layout: ;--tw-contain-paint: ;--tw-contain-style: }*,:after,:before{border:0 solid #e6e6e6;box-sizing:border-box}:after,:before{--tw-content:""}:host,html{line-height:1.5;-webkit-text-size-adjust:100%;font-family:ConsulSans-750,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;font-feature-settings:normal;font-variation-settings:normal;tab-size:4}body{line-height:inherit;margin:0}h1,h3,h5{font-size:inherit;font-weight:inherit}a{color:inherit;text-decoration:inherit}button,input,textarea{color:inherit;font-family:inherit;font-feature-settings:inherit;font-size:100%;font-variation-settings:inherit;font-weight:inherit;letter-spacing:inherit;line-height:inherit;margin:0;padding:0}button{text-transform:none}button{-webkit-appearance:button;background-color:initial;background-image:none}:-moz-focusring{outline:auto}:-moz-ui-invalid{box-shadow:none}::-webkit-inner-spin-button,::-webkit-outer-spin-button{height:auto}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}figure,h1,h3,h5,p{margin:0}ul{list-style:none;margin:0;padding:0}textarea{resize:vertical}iframe,img,svg{display:block;vertical-align:middle}img{height:auto;max-width:100%}.fixed{position:fixed}.relative{position:relative}.z-50{z-index:50}.col-span-4{grid-column:span 4/span 4}.col-span-7{grid-column:span 7/span 7}.col-start-9{grid-column-start:9}.mx-4{margin-left:1rem;margin-right:1rem}.mx-auto{margin-left:auto;margin-right:auto}.my-6{margin-bottom:1.5rem;margin-top:1.5rem}.-mt-24{margin-top:-6rem}.mb-2{margin-bottom:.5rem}.mb-4{margin-bottom:1rem}.mb-6{margin-bottom:1.5rem}.ml-4{margin-left:1rem}.mr-1{margin-right:.25rem}.mr-2{margin-right:.5rem}.mt-1{margin-top:.25rem}.mt-10{margin-top:2.5rem}.mt-24{margin-top:6rem}.mt-6{margin-top:1.5rem}.block{display:block}.inline-block{display:inline-block}.flex{display:flex}.hidden{display:none}.size-full{height:100%;width:100%}.h-3{height:.75rem}.h-48{height:12rem}.h-5{height:1.25rem}.w-3{width:.75rem}.w-48{width:12rem}.w-5{width:1.25rem}.w-full{width:100%}.grid-cols-12{grid-template-columns:repeat(12,minmax(0,1fr))}.flex-col{flex-direction:column}.flex-wrap{flex-wrap:wrap}.items-center{align-items:center}.justify-center{justify-content:center}.space-x-1>:not([hidden])~:not([hidden]){--tw-space-x-reverse:0;margin-left:calc(.25rem*(1 - var(--tw-space-x-reverse)));margin-right:calc(.25rem*var(--tw-space-x-reverse))}.overflow-x-scroll{overflow-x:scroll}.rounded-full{border-radius:9999px}.border-b{border-bottom-width:1px}.bg-gray-100{--tw-bg-opacity:1;background-color:rgb(247 247 247/var(--tw-bg-opacity,1))}.bg-gray-200{--tw-bg-opacity:1;background-color:rgb(242 242 242/var(--tw-bg-opacity,1))}.bg-gray-700{--tw-bg-opacity:1;background-color:rgb(77 77 77/var(--tw-bg-opacity,1))}.bg-purple-500{--tw-bg-opacity:1;background-color:rgb(115 64 96/var(--tw-bg-opacity,1))}.p-6{padding:1.5rem}.px-4{padding-left:1rem;padding-right:1rem}.py-2{padding-bottom:.5rem;padding-top:.5rem}.pb-2{padding-bottom:.5rem}.pb-4{padding-bottom:1rem}.pb-7{padding-bottom:1.75rem}.pt-2{padding-top:.5rem}.pt-4{padding-top:1rem}.text-center{text-align:center}.font-arvo{font-family:Arvo,Georgia,Cambria,Times New Roman,Times,serif}.font-sans{font-family:ConsulSans-750,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji}.text-base{font-size:1rem}.text-kinda-sm{font-size:.938rem}.text-xs{font-size:.75rem}.text-xxs{font-size:.6875rem}.font-bold{font-weight:700}.uppercase{text-transform:uppercase}.italic{font-style:italic}.leading-loose{line-height:2}.leading-none{line-height:1}.tracking-extra-widest{letter-spacing:.12em}.tracking-wider{letter-spacing:.05em}.tracking-widest{letter-spacing:.1em}.text-black{--tw-text-opacity:1;color:rgb(26 26 26/var(--tw-text-opacity,1))}.text-gray-600{--tw-text-opacity:1;color:rgb(128 128 128/var(--tw-text-opacity,1))}.text-gray-700{--tw-text-opacity:1;color:rgb(77 77 77/var(--tw-text-opacity,1))}.text-purple-500{--tw-text-opacity:1;color:rgb(115 64 96/var(--tw-text-opacity,1))}.text-white{--tw-text-opacity:1;color:rgb(255 255 255/var(--tw-text-opacity,1))}.text-yellow-500{--tw-text-opacity:1;color:rgb(237 182 84/var(--tw-text-opacity,1))}.no-underline{text-decoration-line:none}.shadow-md{--tw-shadow:0 4px 6px -1px #0000001a,0 2px 4px -1px #0000000f;--tw-shadow-colored:0 4px 6px -1px var(--tw-shadow-color),0 2px 4px -1px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}body{font-family:Bitter,Georgia,Cambria,Times New Roman,Times,serif;--tw-text-opacity:1;color:rgb(77 77 77/var(--tw-text-opacity,1))}h1{font-family:Domaine Display,Georgia,Cambria,Times New Roman,Times,serif}body.font-drama-loaded .sidebar-heading-you{font-family:Drama Regular;letter-spacing:0;text-transform:lowercase;--tw-text-opacity:1;color:rgb(128 128 128/var(--tw-text-opacity,1))}body.font-drama-loaded .sidebar-heading-you{font-size:4rem;line-height:1.5rem}:root{--poy-color-purple:#734060;--poy-color-yellow:#edb654;--poy-color-black:#1a1a1a;--poy-color-gray:gray;--poy-color-gray-700:#4d4d4d;--poy-color-white:#fff;--poy-font-drama:"Drama Regular",serif;--poy-font-domaine:"Domaine Display","Georgia","Cambria","Times New Roman","Times",serif;--poy-font-arvo:"Arvo","Georgia","Cambria","Times New Roman","Times",serif;--poy-font-menlo:"Menlo","Monaco","Consolas","Liberation Mono","Courier New",monospace;--poy-font-serif:"Bitter","Georgia","Cambria","Times New Roman","Times",serif;--poy-font-sans:"ConsulSans-750","system-ui","-apple-system","BlinkMacSystemFont","Segoe UI","Roboto","Helvetica Neue","Arial","Noto Sans",sans-serif;--poy-font-size-9:.5625rem;--poy-font-size-11:.6875rem;--poy-font-size-13:.8125rem;--poy-font-size-base:1rem;--poy-font-size-h2:1.5625rem;--poy-font-size-h3:1.25rem;--poy-font-size-h4:1.125rem;--poy-spacing-1:0.25rem;--poy-spacing-2:0.5rem;--poy-spacing-3:0.75rem;--poy-spacing-4:1rem;--poy-spacing-5:1.25rem;--poy-spacing-6:1.5rem;--poy-spacing-7:1.75rem;--poy-spacing-8:2rem;--poy-spacing-9:2.25rem;--poy-spacing-10:2.5rem;--poy-spacing-11:2.75rem;--poy-spacing-12:3rem}body{font-family:var(--poy-font-serif)}body p{color:#4d4d4d}.adthrive_header_ad{display:flex;flex-direction:column;justify-content:center;min-height:100px}@media (max-width:768px){.adthrive_header_ad{display:none}}.poy-breadcrumb-container{border-right-width:1px;--tw-border-opacity:1;border-color:rgb(242 242 242/var(--tw-border-opacity,1))}@media (min-width:1024px){.poy-breadcrumb-container{border-style:none}}@media screen and (max-width:768px){.single-post .poy-breadcrumb-container{margin-bottom:1rem}}.poy-breadcrumb{display:inline-flex;padding-left:1rem;padding-right:1rem}.poy-breadcrumb>span>span{padding-right:.5rem}.poy-breadcrumb>span>span{align-items:center;display:inline-flex}.poy-breadcrumb .breadcrumb_last,.poy-breadcrumb a{display:inline-flex;font-family:ConsulSans-750,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;font-size:.6875rem;letter-spacing:.1em;overflow-x:scroll;padding-bottom:.25rem;padding-top:.25rem;text-transform:uppercase;white-space:nowrap}@media screen and (min-width:992px){.poy-breadcrumb-container{box-shadow:none}.poy-breadcrumb .breadcrumb_last,.poy-breadcrumb a{overflow-x:auto;white-space:normal}}.poy-breadcrumb a{margin-right:.5rem;padding-right:1rem;position:relative}.poy-breadcrumb a:after{background-image:url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 5.9 9.5'%3E%3Cg data-name='Layer 2'%3E%3Cpath fill='currentColor' d='m0 8.4 3.6-3.6L0 1.1 1.1 0l4.8 4.8-4.8 4.7Z' data-name='Layer 1'/%3E%3C/g%3E%3C/svg%3E");background-repeat:no-repeat;background-size:contain;content:" ";display:inline-block;height:8px;position:absolute;width:6px}.poy-breadcrumb.gray-post-breadcrumb .breadcrumb_last,.poy-breadcrumb.gray-post-breadcrumb a{--tw-text-opacity:1;color:rgb(77 77 77/var(--tw-text-opacity,1))}.poy-breadcrumb.gray-post-breadcrumb .breadcrumb_last a:after{background-image:none}.poy-breadcrumb.gray-post-breadcrumb a:after{opacity:.3;right:0;top:7px}.entry-content .aligncenter{clear:both}h1.entry-title{font-family:Domaine Display,Georgia,Cambria,Times New Roman,Times,serif;font-size:2rem;line-height:1.125;--tw-text-opacity:1;color:rgb(26 26 26/var(--tw-text-opacity,1))}@media screen and (min-width:768px){h1.entry-title{font-size:2.625rem}}.entry-content h3{font-family:ConsulSans-750,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;font-size:1.25rem;letter-spacing:.025em;--tw-text-opacity:1;color:rgb(128 128 128/var(--tw-text-opacity,1))}.entry-content p{font-size:1rem;margin-bottom:1.5rem;--tw-text-opacity:1;color:rgb(77 77 77/var(--tw-text-opacity,1))}@media screen and (min-width:768px){.entry-content p{font-size:1.063em}}.entry-content :is(li,p) a{--tw-text-opacity:1;color:rgb(115 64 96/var(--tw-text-opacity,1));text-decoration-line:none}@supports (text-decoration-thickness:2px){.entry-content :is(li,p) a{text-decoration-color:#edb654;text-decoration-line:underline;text-decoration-thickness:2px}}@supports not (text-decoration-thickness:2px){.entry-content :is(li,p) a{border-bottom:2px solid #edb654}}.entry-content ul:not(.wp-block-social-links) li{margin-bottom:.5rem}.entry-content ul:not(.wp-block-social-links) li:before{content:"";display:block;height:8px;left:12px;margin-top:7px;width:8px}.entry-content ul:not(.wp-block-social-links) li:before{border-radius:9999px;position:absolute;--tw-bg-opacity:1;background-color:rgb(115 64 96/var(--tw-bg-opacity,1))}.entry-content :is(.wp-block-embed-youtube,.wp-block-image){margin-bottom:1.5rem}.comment-respond input{border-width:1px;margin-bottom:.5rem;margin-top:.5rem;max-width:100%;--tw-border-opacity:1;border-color:rgb(204 204 204/var(--tw-border-opacity,1));padding:.5rem;--tw-shadow:inset 0 4px 0 1px rgba(0,0,0,.075);--tw-shadow-colored:inset 0 4px 0 1px var(--tw-shadow-color);box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}.comment-respond label{display:block;font-family:Arvo,Georgia,Cambria,Times New Roman,Times,serif;font-size:.75rem;letter-spacing:.1em;text-transform:uppercase;--tw-text-opacity:1;color:rgb(115 64 96/var(--tw-text-opacity,1))}.featured-comment .tasty-recipes-ratings{display:none}.featured-comment .featured-comment-content p:before{content:"“"}.featured-comment .featured-comment-content p:after{content:"”"}@media screen and (max-width:576px){#burgerBtn{border-top-width:2px;position:absolute;--tw-border-opacity:1;border-color:rgb(77 77 77/var(--tw-border-opacity,1));height:25px;right:20px;top:20px;width:30px}#burgerBtn:before{top:10px}#burgerBtn:after,#burgerBtn:before{display:block;left:0;position:absolute;--tw-bg-opacity:1;background-color:rgb(77 77 77/var(--tw-bg-opacity,1));content:"";height:2px;width:30px}#burgerBtn:after{bottom:0}.menu{background-color:rgb(255 255 255/var(--tw-bg-opacity,1));height:100vh;overflow:hidden;position:absolute;--tw-bg-opacity:0.95;left:0;top:76px;z-index:1000}.menu li{margin-top:20px;width:0}.menu li+li{margin-left:-40px}.menu li+li+li{margin-left:-80px}.menu li+li+li+li{margin-left:-120px}}.entry-content .tasty-recipes .tasty-recipes-label{font-family:Arvo,Georgia,Cambria,Times New Roman,Times,serif;font-size:.6875rem;letter-spacing:.05em;text-transform:uppercase}.entry-content .tasty-recipes .tasty-recipes-entry-header .tasty-recipes-details ul li{line-height:1.5}.entry-content .tasty-recipes .tasty-recipes-entry-header .tasty-recipes-details ul .author,.entry-content .tasty-recipes .tasty-recipes-entry-header .tasty-recipes-details ul li:before{display:none}.entry-content .tasty-recipes .tasty-recipes-entry-header .tasty-recipes-details .tasty-recipes-label{font-style:normal;--tw-text-opacity:1;color:rgb(211 185 204/var(--tw-text-opacity,1))}.entry-content .tasty-recipes .tasty-recipes-entry-content h3{font-family:Arvo,Georgia,Cambria,Times New Roman,Times,serif;font-size:.938rem;margin-bottom:1rem;--tw-text-opacity:1;color:rgb(128 128 128/var(--tw-text-opacity,1))}article .tasty-recipes-quick-links{display:block;margin-bottom:1rem;text-align:center}article .tasty-recipes-quick-links a.tasty-recipes-jump-link{display:block;--tw-bg-opacity:1;background-color:rgb(247 247 247/var(--tw-bg-opacity,1));font-family:ConsulSans-750,system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji;font-size:.875rem;letter-spacing:.1em;line-height:.75rem;padding-bottom:.75rem;padding-top:.75rem;text-transform:uppercase;--tw-text-opacity:1;color:rgb(115 64 96/var(--tw-text-opacity,1))}article .tasty-recipes-quick-links a.tasty-recipes-jump-link:before{content:url(https://pinchofyum.com/content/assets/images/icons/icon-arrow.svg);display:inline-block;height:.75rem;margin-right:.5rem;vertical-align:initial;width:.75rem}:is(.category,.entry-header,.page-recipes) .tasty-recipes-rating svg{height:1.25rem;width:1.25rem}.tasty-recipes-ratings{font-size:1.1em;font-size:var(--tr-star-size);gap:.3em;gap:var(--tr-star-margin)}.tasty-recipes-ratings span.tasty-recipes-rating{width:1.1em;width:var(--tr-star-size)}.entry-header .tasty-recipes-rating-outline svg{padding:.05425rem .1085rem .16375rem}.tasty-recipes-rating{font-size:1.25rem;--tw-text-opacity:1;color:rgb(237 182 84/var(--tw-text-opacity,1))}@media (min-width:640px){.sm\:mt-2{margin-top:.5rem}.sm\:flex{display:flex}.sm\:w-64{width:16rem}.sm\:items-center{align-items:center}.sm\:justify-between{justify-content:space-between}}@media (min-width:768px){.md\:relative{position:relative}.md\:z-auto{z-index:auto}.md\:block{display:block}.md\:grid{display:grid}.md\:hidden{display:none}.md\:max-w-6xl{max-width:72rem}.md\:border-b-3{border-bottom-width:3px}.md\:border-transparent{border-color:#0000}.md\:pb-2{padding-bottom:.5rem}.md\:pt-8{padding-top:2rem}.md\:text-sm{font-size:.875rem}.md\:tracking-extra-widest{letter-spacing:.12em}.md\:shadow-none{--tw-shadow:0 0 #0000;--tw-shadow-colored:0 0 #0000;box-shadow:var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow)}}@media (min-width:1024px){.lg\:mx-auto{margin-left:auto;margin-right:auto}.lg\:max-w-6xl{max-width:72rem}.lg\:overflow-x-auto{overflow-x:auto}}</style>
+<link rel='stylesheet' id='poy-style-css' href='https://pinchofyum.com/content/assets/dist/style.css?r=1784319909&#038;ver=7.0.2' media="print" onload="this.media='all'; this.onload=null;" />
+<style id="poy-style-inline-css">
+
+	@media (min-width: 640px) {
+		.sm\:-mb-7 {
+			margin-bottom: -1.75rem;
+		}
+	}
+	.poy-breadcrumb > span > span,
+	.poy-breadcrumb > span > span span {
+		display: inline-flex;
+	}
+	.poy-breadcrumb a {
+		margin-right: 0rem;
+		padding-right: 1rem;
+	}
+	.grid {
+		display: grid;
+	}
+	.gap-4 {
+		gap: 1rem;
+	}
+	@media (min-width: 768px) {
+		.md\:col-span-3 {
+			grid-column: span 3 / span 3;
+		}
+	}
+/*# sourceURL=poy-style-inline-css */
+</style>
+<link rel='stylesheet' id='convertkit-admin-quicktags-css' href='https://pinchofyum.com/content/plugins/convertkit/resources/backend/css/quicktags.css?ver=3.3.5' media='all' />
+<style id="tasty-recipes-before-inline-css">
+body{--tr-star-color:#F2B955;--tr-button-text-color:#fff;--tr-radius:2px}
+/*# sourceURL=tasty-recipes-before-inline-css */
+</style>
+<link rel='stylesheet' id='tasty-recipes-main-css' href='https://pinchofyum.com/content/plugins/tasty-recipes/inc/libs/tasty-recipes-lite/assets/dist/recipe.css?ver=1.2.6' media='all' />
+<style id="tasty-recipes-main-inline-css">
+/* Bold recipe card styles. */ .tasty-recipes{border:5px solid #667;margin-top:6em;margin-bottom:4em}.tasty-recipes.tasty-recipes-has-plug{margin-bottom:1em}.tasty-recipes-plug{margin-bottom:4em}.tasty-recipes-print-button{display:none}.tasty-recipes-image-shim{height:69.5px;clear:both}.tasty-recipes-entry-header{background-color:#667;color:#fff;text-align:center;padding-top:35px;padding-bottom:1.5em;padding-left:2.5em;padding-right:2.5em}.tasty-recipes-entry-header.tasty-recipes-has-image{padding-top:0px}.tasty-recipes-entry-header .tasty-recipes-image{float:none;text-align:center;transform:translateY(-115px);margin-bottom:1em;/* Decide if we need this */}.tasty-recipes-entry-header .tasty-recipes-image img{-webkit-border-radius:50%;-moz-border-radius:50%;border-radius:50%;border:5px solid #667;height:150px;width:150px;display:inline-block;object-fit:cover}.tasty-recipes-entry-header h2{font-size:2em;font-weight:400;text-transform:lowercase;margin-bottom:0;text-align:center;color:#fff;margin-top:0;padding-top:0;padding-bottom:0}.tasty-recipes-has-image .tasty-recipes-entry-header h2{margin-top:-115px}.tasty-recipes-entry-header hr{border:1px solid #b7bbc6;background-color:#b7bbc6;margin-bottom:1em;margin-top:1em}.tasty-recipes-entry-header div.tasty-recipes-rating{text-decoration:none;border:none;display:block;font-size:1.375em}.tasty-recipes-entry-header .tasty-recipes-rating:hover{text-decoration:none}.tasty-recipes-entry-header .tasty-recipes-rating p{margin-bottom:0}.tasty-recipes-no-ratings-buttons .unchecked,.tasty-recipes-no-ratings-buttons .checked,.tasty-recipes-entry-header span.tasty-recipes-rating{color:#fff;color:var(--tr-star-color,#fff)}.tasty-recipes-entry-header .rating-label{font-style:italic;color:#b7bbc6;font-size:0.6875em;display:block}.tasty-recipes,.tasty-recipes-ratings{--tr-star-size:0.97em!important;--tr-star-margin:0.5em!important}.tasty-recipes-entry-header .tasty-recipes-details{margin-top:1em}.tasty-recipes-entry-header .tasty-recipes-details ul{list-style-type:none;margin:0}.tasty-recipes-entry-header .tasty-recipes-details ul li{display:inline-block;margin-left:0.5em;margin-right:0.5em;font-size:1em;line-height:2.5em;color:#fff}@media only screen and (max-width:520px){.tasty-recipes-entry-header .tasty-recipes-details .detail-icon{height:0.8em;margin-top:0.4em}.tasty-recipes-entry-header .tasty-recipes-details ul li{font-size:0.875em;line-height:1.75em}}@media only screen and (min-width:520px){.tasty-recipes-entry-header .tasty-recipes-details .detail-icon{height:1em;margin-top:0.6em}.tasty-recipes-entry-header .tasty-recipes-details ul li{font-size:1em;line-height:2.5em}}.tasty-recipes-entry-header .tasty-recipes-details .tasty-recipes-label{font-style:italic;color:#b7bbc6;margin-right:0.125em}.tasty-recipes-entry-header .tasty-recipes-details .detail-icon{vertical-align:top;margin-right:0.2em;display:inline-block;color:#FFF}.tasty-recipes-entry-header .tasty-recipes-details .author a{color:inherit;text-decoration:underline}.tasty-recipes-entry-content{padding-top:1.25em}.tasty-recipes-entry-content .tasty-recipes-buttons{margin-bottom:1.25em;margin-left:1.25em;margin-right:1.25em}.tasty-recipes-entry-content .tasty-recipes-buttons:after{content:' ';display:block;clear:both}.tasty-recipes-entry-content .tasty-recipes-button-wrap{width:50%;display:inline-block;float:left;box-sizing:border-box}.tasty-recipes-quick-links a.button,.tasty-recipes-entry-content .tasty-recipes-buttons a{text-transform:uppercase;text-align:center;display:block;color:#fff;color:var(--tr-button-text-color,#fff);background-color:#667;background-color:var(--tr-button-color,#666677);font-size:1em;line-height:1.375em;padding:1em;font-weight:bold;margin-top:0;border:none;border-radius:0;text-decoration:none}.tasty-recipes-quick-links a.button{display:inline-flex;align-items:center;justify-content:center;padding:8px;line-height:16px;border-radius:4px;white-space:nowrap}.tasty-recipes-entry-content a img{box-shadow:none;-webkit-box-shadow:none}.tasty-recipes-quick-links a.button:hover,.tasty-recipes-entry-content .tasty-recipes-buttons a:hover{border:none}.tasty-recipes-entry-content .tasty-recipes-buttons img{vertical-align:top}.tasty-recipes-entry-content .tasty-recipes-buttons .svg-print,.tasty-recipes-entry-content .tasty-recipes-buttons .svg-pinterest,.tasty-recipes-entry-content .tasty-recipes-buttons .svg-heart-regular,.tasty-recipes-entry-content .tasty-recipes-buttons .svg-heart-solid{height:1.25em;margin-right:0.375em;margin-bottom:0;background:none;display:inline-block;vertical-align:middle}@media only screen and (min-width:520px){.tasty-recipes-entry-content .tasty-recipes-button-wrap:first-child{padding-right:0.625em}.tasty-recipes-entry-content .tasty-recipes-button-wrap:last-child{padding-left:0.625em}}@media only screen and (max-width:520px){.tasty-recipes-entry-content .tasty-recipes-button-wrap{width:100%}.tasty-recipes-entry-content .tasty-recipes-button-wrap:nth-child(2){padding-top:1em}}.tasty-recipes-entry-content h3{text-transform:uppercase;font-size:0.75em;color:#979599;margin:1.5em 0}.tasty-recipes-ingredients-header,.tasty-recipes-instructions-header{margin:1.5em 0}.tasty-recipes-entry-content h4{font-size:1em;padding-top:0;margin-bottom:1.5em;margin-top:1.5em}.tasty-recipes-entry-content hr{background-color:#eae9eb;border:1px solid #eae9eb;margin-top:1em;margin-bottom:1em}.tasty-recipes-entry-content .tasty-recipes-description,.tasty-recipes-entry-content .tasty-recipes-ingredients,.tasty-recipes-entry-content .tasty-recipes-instructions,.tasty-recipes-entry-content .tasty-recipes-keywords{padding-left:1.25em;padding-right:1.25em}.tasty-recipes-entry-content .tasty-recipes-description h3{display:none}.tasty-recipes-entry-content .tasty-recipes-description p{margin-bottom:1em}.tasty-recipes-entry-content .tasty-recipes-ingredients ul,.tasty-recipes-entry-content .tasty-recipes-instructions ul{list-style-type:none;margin-left:0;margin-bottom:1.5em;padding:0}.tasty-recipes-entry-content .tasty-recipes-ingredients ul li,.tasty-recipes-entry-content .tasty-recipes-instructions ul li{margin-bottom:0.625em;list-style-type:none;position:relative;margin-left:1.5em;line-height:1.46}.tasty-recipes-entry-content .tasty-recipes-ingredients ul li:before,.tasty-recipes-entry-content .tasty-recipes-instructions ul li:before{background-color:#667;-webkit-border-radius:50%;-moz-border-radius:50%;border-radius:50%;height:0.5em;width:0.5em;display:block;content:' ';left:-1.25em;top:0.375em;position:absolute}.tasty-recipes-entry-content .tasty-recipes-ingredients ol,.tasty-recipes-entry-content .tasty-recipes-instructions ol{counter-reset:li;margin-left:0;padding:0}.tasty-recipes-entry-content .tasty-recipes-ingredients ol>li,.tasty-recipes-entry-content .tasty-recipes-instructions ol>li{list-style-type:none;position:relative;margin-bottom:1em;margin-left:1.5em;line-height:1.46}.tasty-recipes-entry-content .tasty-recipes-ingredients ol>li:before,.tasty-recipes-entry-content .tasty-recipes-instructions ol>li:before{content:counter(li);counter-increment:li;position:absolute;background-color:#667;-webkit-border-radius:50%;-moz-border-radius:50%;border-radius:50%;height:1.45em;width:1.45em;color:#fff;left:-1.25em;transform:translateX(-50%);line-height:1.5em;font-size:0.6875em;text-align:center;top:0.1875em}.tasty-recipes-entry-content .tasty-recipes-ingredients li li,.tasty-recipes-entry-content .tasty-recipes-instructions li li{margin-top:0.625em}.tasty-recipes-entry-content .tasty-recipes-ingredients li ul,.tasty-recipes-entry-content .tasty-recipes-ingredients li ol,.tasty-recipes-entry-content .tasty-recipes-instructions li ul,.tasty-recipes-entry-content .tasty-recipes-instructions li ol{margin-bottom:0}.tasty-recipes-entry-content .tasty-recipes-equipment{padding-left:1.25em;padding-right:1.25em}.tasty-recipes-entry-content .tasty-recipe-video-embed~.tasty-recipes-equipment{padding-top:1em}.tasty-recipes-entry-content .tasty-recipes-notes{padding:1.25em;background-color:#edf0f2}.tasty-recipes-entry-content .tasty-recipes-notes ol{counter-reset:li;margin-left:0;padding:0}.tasty-recipes-entry-content .tasty-recipes-notes ul{margin-left:0;padding:0}.tasty-recipes-entry-content .tasty-recipes-notes p,.tasty-recipes-entry-content .tasty-recipes-notes ul,.tasty-recipes-entry-content .tasty-recipes-notes ol{background-color:#fff;padding-bottom:1.25em;margin-bottom:1.5em;position:relative;-webkit-clip-path:polygon(20px 0,100% 0,100% 100%,0 100%,0 20px);clip-path:polygon(20px 0,100% 0,100% 100%,0 100%,0 20px)}@media only screen and (min-width:520px){.tasty-recipes-entry-content .tasty-recipes-notes p,.tasty-recipes-entry-content .tasty-recipes-notes ul,.tasty-recipes-entry-content .tasty-recipes-notes ol{padding-left:1.5625em;padding-right:1.5625em;padding-top:1.25em}.tasty-recipes-entry-content .tasty-recipes-notes ul,.tasty-recipes-entry-content .tasty-recipes-notes ol{margin-left:2em}}.tasty-recipes-entry-content .tasty-recipes-notes p,.tasty-recipes-entry-content .tasty-recipes-notes ul li,.tasty-recipes-entry-content .tasty-recipes-notes ol li{padding-left:2.5em}.tasty-recipes-entry-content .tasty-recipes-notes ul li,.tasty-recipes-entry-content .tasty-recipes-notes ol li{position:relative;list-style:none;padding-top:1em;margin-left:0;margin-bottom:0}.tasty-recipes-entry-content .tasty-recipes-notes p:before,.tasty-recipes-entry-content .tasty-recipes-notes ul li:before{content:'i';display:block;background-color:#667;-webkit-border-radius:50%;-moz-border-radius:50%;border-radius:50%;height:1.3em;width:1.3em;font-size:0.75em;line-height:1.3em;text-align:center;color:#fff;position:absolute;left:1.167em;top:1.9em}.tasty-recipes-entry-content .tasty-recipes-notes ol>li:before{content:counter(li);counter-increment:li;position:absolute;background-color:#667;-webkit-border-radius:50%;-moz-border-radius:50%;border-radius:50%;height:1.45em;width:1.45em;color:#fff;left:2em;transform:translateX(-50%);line-height:1.5em;font-size:0.6875em;text-align:center;top:2em}.tasty-recipes-entry-content .tasty-recipes-notes p:last-child{margin-bottom:0}.tasty-recipes-entry-content .tasty-recipes-other-details{background-color:#edf0f2;padding:0 1.25em 1.25em}.tasty-recipes-entry-content .tasty-recipes-other-details ul{color:#667;display:flex;flex-wrap:wrap;font-size:0.85rem;list-style:none;margin-bottom:0}.tasty-recipes-entry-content .tasty-recipes-other-details ul li{margin:0 0.5rem;list-style:none}.tasty-recipes-entry-content .tasty-recipes-other-details ul li .tasty-recipes-label{font-style:italic}.tasty-recipes-entry-content .tasty-recipes-other-details .detail-icon{color:#667;vertical-align:top;margin-right:0.2em;display:inline-block}@media only screen and (max-width:520px){.tasty-recipes-entry-content .tasty-recipes-other-details .detail-icon{height:0.8em;margin-top:0.4em}.tasty-recipes-entry-content .tasty-recipes-other-details ul li{font-size:0.875em;line-height:1.75em}}@media only screen and (min-width:520px){.tasty-recipes-entry-content .tasty-recipes-other-details .detail-icon{height:1em;margin-top:0.8em}.tasty-recipes-entry-content .tasty-recipes-other-details ul li{font-size:1em;line-height:2.5em}}.tasty-recipes-entry-content .tasty-recipes-keywords{background-color:#edf0f2;padding-bottom:1em;padding-top:1em}.tasty-recipes-entry-content .tasty-recipes-keywords p{font-size:0.7em;font-style:italic;color:#979599;margin-bottom:0}.tasty-recipes-entry-content .tasty-recipes-keywords p span{font-weight:bold}.tasty-recipes-nutrifox{text-align:center;margin:0}.nutrifox-label{background-color:#edf0f2}.tasty-recipes-nutrifox iframe{width:100%;display:block;margin:0}.tasty-recipes-entry-content .tasty-recipes-nutrition{padding:1.25em;color:#667}.tasty-recipes-nutrition .tasty-recipes-label{font-style:italic;color:#b7bbc6;margin-right:0.125em;font-weight:400}.tasty-recipes-nutrition ul li{float:none;display:inline-block;line-height:2em;margin:0 10px 0 0}.tasty-recipes-entry-footer{background-color:#667}.tasty-recipes-entry-footer img,.tasty-recipes-entry-footer svg{color:#FFF}.tasty-recipes-entry-content .tasty-recipes-entry-footer h3{color:#fff}.tasty-recipes-entry-footer{color:#fff}.tasty-recipes-entry-footer:after{content:' ';display:block;clear:both}/* Print view styles */ .tasty-recipes-print-view .tasty-recipe-video-embed,.tasty-recipes-print-view .tasty-recipes-other-details,.tasty-recipes-print .tasty-recipes-entry-header .tasty-recipes-details .detail-icon,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-notes p:before,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-notes ul li:before,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-ingredients ul li:before,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-ingredients ol li:before,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-instructions ul li:before,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-instructions ol li:before,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-notes ol>li:before,.tasty-recipes-print .tasty-recipes-entry-footer img{display:none}.tasty-recipes-print-view{font-size:11px;background-color:#fff;line-height:1.5em}.tasty-recipes-print{padding:0}.tasty-recipes-print-view .tasty-recipes{margin-top:1em}.tasty-recipes-print-view .tasty-recipes-entry-content h3{font-size:1.2em;letter-spacing:0.1em;margin:0 0 10px 0}.tasty-recipes-print-view .tasty-recipes-ingredients-header,.tasty-recipes-print-view .tasty-recipes-instructions-header{margin:0}.tasty-recipes-print-view .tasty-recipes-ingredients,.tasty-recipes-print-view .tasty-recipes-instructions{padding:1.25em}.tasty-recipes-print .tasty-recipes-entry-header{background-color:inherit;color:inherit;padding:0;text-align:left}.tasty-recipes-print .tasty-recipes-entry-header .tasty-recipes-image{float:right;transform:none}.tasty-recipes-print.tasty-recipes-has-image .tasty-recipes-entry-header h2{margin-top:0;text-align:left}.tasty-recipes-print .tasty-recipes-entry-header h2{color:inherit;margin-bottom:0.5em}.tasty-recipes-print .tasty-recipes-entry-header hr{display:none}.tasty-recipes-print .tasty-recipes-entry-header span.tasty-recipes-rating{color:#000}.tasty-recipes-entry-header div.tasty-recipes-rating a{text-decoration:none}.tasty-recipes-entry-header div.tasty-recipes-rating p{margin-top:4px}.tasty-recipes-print .tasty-recipes-entry-header .tasty-recipes-details ul{padding:0;clear:none}.tasty-recipes-print .tasty-recipes-entry-header .tasty-recipes-details ul li{line-height:1.5em;color:#000;margin:0 10px 0 0}.tasty-recipes-print .tasty-recipes-entry-content img{max-width:50%;height:auto}.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-ingredients ol li,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-instructions ol li{margin-bottom:0.5em;list-style:decimal;line-height:1.5em}.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-ingredients ul li,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-instructions ul li{margin-bottom:0.5em;line-height:1.1;list-style:disc}.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-notes{background:none!important}.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-notes ul,.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-notes ol{background:none!important}.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-notes ol li{padding:0;clip-path:none;background:none;line-height:1.5em;list-style:decimal}.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-notes p{padding:0;clip-path:none;background:none;line-height:1.5em}.tasty-recipes-print .tasty-recipes-entry-content .tasty-recipes-notes ul li{padding:0;clip-path:none;background:none;line-height:1.5em;list-style:disc}.tasty-recipes-print .tasty-recipes-source-link{text-align:center}.tasty-recipes-entry-content .tasty-recipes-ingredients ul li[data-tr-ingredient-checkbox]:before{display:none}.tasty-recipes-cook-mode{margin-top:1em}.tasty-recipes-cook-mode__label{font-style:italic;color:#667;font-weight:normal}.tasty-recipes-cook-mode__helper{font-size:1em}.tasty-recipes-cook-mode .tasty-recipes-cook-mode__switch .tasty-recipes-cook-mode__switch-slider{background-color:#667}
+/*# sourceURL=tasty-recipes-main-inline-css */
+</style>
+<link rel="https://api.w.org/" href="https://pinchofyum.com/wp-json/" /><link rel="alternate" title="JSON" type="application/json" href="https://pinchofyum.com/wp-json/wp/v2/posts/23546" /><meta name="generator" content="Altis (WordPress 7.0.2)" />
+<link rel='shortlink' href='https://pinchofyum.com/?p=23546' />
+<!-- Stream WordPress user activity plugin v4.2.2 -->
+
+
+<!-- [slickstream] [[[ START Slickstream Output ]]] -->
+<script>console.info(`[slickstream] Page Generated at: 7/22/2026, 11:12:16 PM EST`);</script>
+<script>console.info(`[slickstream] Current timestamp: ${(new Date).toLocaleString('en-US', { timeZone: 'America/New_York' })} EST`);</script>
+<!-- [slickstream] Page Boot Data: -->
+<script class='slickstream-script'>
+(function() {
+    "slickstream";
+    const win = window;
+    win.$slickBoot = win.$slickBoot || {};
+    win.$slickBoot.d = {"bestBy":1784779227894,"epoch":1770159634142,"siteCode":"L8EAVD26","services":{"engagementCacheableApiDomain":"https:\/\/c01f.app.slickstream.com\/","engagementNonCacheableApiDomain":"https:\/\/c01b.app.slickstream.com\/","engagementResourcesDomain":"https:\/\/c01f.app.slickstream.com\/","storyCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyNonCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyResourcesDomain":"https:\/\/stories.slickstream.com\/","websocketUri":"wss:\/\/c01b-wss.app.slickstream.com\/socket?site=L8EAVD26"},"bootUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/boot-loader.js","appUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/app.js","adminUrl":"","allowList":["pinchofyum.com"],"abTests":[],"wpPluginTtl":3600,"v2":{"phone":{"placeholders":[],"bootTriggerTimeout":250,"bestBy":1784779227894,"epoch":1770159634142,"siteCode":"L8EAVD26","services":{"engagementCacheableApiDomain":"https:\/\/c01f.app.slickstream.com\/","engagementNonCacheableApiDomain":"https:\/\/c01b.app.slickstream.com\/","engagementResourcesDomain":"https:\/\/c01f.app.slickstream.com\/","storyCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyNonCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyResourcesDomain":"https:\/\/stories.slickstream.com\/","websocketUri":"wss:\/\/c01b-wss.app.slickstream.com\/socket?site=L8EAVD26"},"bootUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/boot-loader.js","appUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/app.js","adminUrl":"","allowList":["pinchofyum.com"],"abTests":[],"wpPluginTtl":3600},"tablet":{"placeholders":[],"bootTriggerTimeout":250,"bestBy":1784779227894,"epoch":1770159634142,"siteCode":"L8EAVD26","services":{"engagementCacheableApiDomain":"https:\/\/c01f.app.slickstream.com\/","engagementNonCacheableApiDomain":"https:\/\/c01b.app.slickstream.com\/","engagementResourcesDomain":"https:\/\/c01f.app.slickstream.com\/","storyCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyNonCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyResourcesDomain":"https:\/\/stories.slickstream.com\/","websocketUri":"wss:\/\/c01b-wss.app.slickstream.com\/socket?site=L8EAVD26"},"bootUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/boot-loader.js","appUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/app.js","adminUrl":"","allowList":["pinchofyum.com"],"abTests":[],"wpPluginTtl":3600},"desktop":{"placeholders":[],"bootTriggerTimeout":250,"bestBy":1784779227894,"epoch":1770159634142,"siteCode":"L8EAVD26","services":{"engagementCacheableApiDomain":"https:\/\/c01f.app.slickstream.com\/","engagementNonCacheableApiDomain":"https:\/\/c01b.app.slickstream.com\/","engagementResourcesDomain":"https:\/\/c01f.app.slickstream.com\/","storyCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyNonCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyResourcesDomain":"https:\/\/stories.slickstream.com\/","websocketUri":"wss:\/\/c01b-wss.app.slickstream.com\/socket?site=L8EAVD26"},"bootUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/boot-loader.js","appUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/app.js","adminUrl":"","allowList":["pinchofyum.com"],"abTests":[],"wpPluginTtl":3600},"unknown":{"placeholders":[],"bootTriggerTimeout":250,"bestBy":1784779227894,"epoch":1770159634142,"siteCode":"L8EAVD26","services":{"engagementCacheableApiDomain":"https:\/\/c01f.app.slickstream.com\/","engagementNonCacheableApiDomain":"https:\/\/c01b.app.slickstream.com\/","engagementResourcesDomain":"https:\/\/c01f.app.slickstream.com\/","storyCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyNonCacheableApiDomain":"https:\/\/stories.slickstream.com\/","storyResourcesDomain":"https:\/\/stories.slickstream.com\/","websocketUri":"wss:\/\/c01b-wss.app.slickstream.com\/socket?site=L8EAVD26"},"bootUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/boot-loader.js","appUrl":"https:\/\/c.slickstream.com\/app\/3.1.9\/app.js","adminUrl":"","allowList":["pinchofyum.com"],"abTests":[],"wpPluginTtl":3600}}};
+    win.$slickBoot.rt = 'https://app.slickstream.com';
+    win.$slickBoot.s = 'plugin';
+    win.$slickBoot._bd = performance.now();
+})();
+</script>
+<!-- [slickstream] END Page Boot Data -->
+<!-- [slickstream] Embed Code -->
+<script id="slick-embed-code-script" class='slickstream-script'>
+"use strict";(async function(t,e){var o;if(location.search.includes("no-slick")){console.log("[Slickstream] Found `no-slick` in location.search; exiting....");return}const n="3.0.0";function i(){return performance.now()}function s(t,e="GET"){return new Request(t,{cache:"no-store",method:e})}function c(t){const e=document.createElement("script");e.className="slickstream-script";e.src=t;document.head.appendChild(e)}function a(t){return t==="ask"||t==="not-required"||t==="na"?t:"na"}async function r(t,e){let o=0;try{if(!("caches"in self))return{};const n=await caches.open("slickstream-code");if(!n)return{};let s=await n.match(t);if(!s){o=i();console.info(`[Slickstream] Adding item to browser cache: ${t.url}`);await n.add(t);s=await n.match(t)}if(!s||!s.ok){if(s){await n.delete(t)}return{}}const c=s.headers.get("x-slickstream-consent");if(!c){console.info("[Slickstream] No x-slickstream-consent header found in cached response")}return{t:o,d:e?await s.blob():await s.json(),c:a(c)}}catch(t){console.log(t);return{}}}async function l(o=false){let c;let l=Object.assign(Object.assign({},window.$slickBoot||{}),{_es:i(),rt:t,ev:n,l:r});const d=t.startsWith("https://")?"":"https://";const u=`${d}${t}/d/page-boot-data?site=${e}&url=${encodeURIComponent(location.href.split("#")[0])}`;const f=s(u);if(o){const{t:t,d:e,c:o}=await r(f);if(e&&e.bestBy>=Date.now()){c=e;if(t){l._bd=t}if(o){l.c=a(o)}}}if(!c){l._bd=i();const t=await fetch(f);const e=t.headers.get("x-slickstream-consent");l.c=a(e);try{c=await t.json()}catch(t){console.error(`[Slickstream] Error parsing page-boot-data from ${f.url}: ${(t===null||t===void 0?void 0:t.message)||""}`,t);return null}}if(c){l=Object.assign(Object.assign({},l),{d:c,s:"embed"})}return l}let d=(o=window.$slickBoot)!==null&&o!==void 0?o:{};if(!(d===null||d===void 0?void 0:d.d)||d.d.bestBy<Date.now()){const t=(d===null||d===void 0?void 0:d.consentStatus)||"denied";const e=t!=="denied";const o=await l(e);if(o){window.$slickBoot=d=o}}if(!(d===null||d===void 0?void 0:d.d)){console.error("[Slickstream] Boot failed; boot data not found after fetching");return}let u=d===null||d===void 0?void 0:d.d.bootUrl;if(!u){console.error("[Slickstream] Bootloader URL not found in boot data");return}let f;let w;if((d===null||d===void 0?void 0:d.consentStatus)&&d.consentStatus!=="denied"){const t=await r(s(u),true);f=t.t;w=t.d}else{f=i();const t=await fetch(s(u));w=await t.blob()}if(w){d.bo=u=URL.createObjectURL(w);if(f){d._bf=f}}else{d._bf=i()}window.$slickBoot=d;document.dispatchEvent(new CustomEvent("slick-boot-ready"));c(u)})("https://app.slickstream.com","L8EAVD26");
+</script>
+<!-- [slickstream] END Embed Code -->
+<!-- [slickstream] Page Metadata: -->
+<meta property='slick:wpversion' content='3.0.1' />
+<meta property="slick:wppostid" content="23546" />
+<meta property="slick:featured_image" content="https://pinchofyum.com/uploads/Easy-Shrimp-Tacos.jpg" />
+<meta property="slick:group" content="post" />
+<meta property="slick:category" content="all:All Recipes" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="avocado:Avocado" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="dinner:Dinner" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="fish:Fish and Seafood" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="lime:Lime" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="lunch:Lunch" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="main-dishes:Main Dishes" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="popular:Most Popular" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="quick-and-easy:Quick and Easy" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="sugar-free:Sugar-Free" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="summer:Summer" />
+<meta property=";" content="recipes:Recipes" />
+<meta property="slick:category" content="taco:Tacos" />
+<meta property=";" content="recipes:Recipes" />
+<script type="application/x-slickstream+json">{"@context":"https://slickstream.com","@graph":[{"@type":"Plugin","version":"3.0.1"},{"@type":"Site","name":"Pinch of Yum","url":"https://pinchofyum.com","description":"A food blog with simple and tasty recipes.","atomUrl":"https://pinchofyum.com/feed/atom","rtl":false},{"@type":"WebPage","@id":23546,"isFront":false,"isHome":false,"isCategory":false,"isTag":false,"isSingular":true,"date":"2022-06-24T04:00:00-05:00","modified":"2026-01-05T12:56:09-06:00","title":"Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw","pageType":"post","postType":"post","featured_image":"https://pinchofyum.com/uploads/Easy-Shrimp-Tacos.jpg","author":"Lindsay","categories":[{"@id":19517,"parent":22,"slug":"all","name":"All Recipes","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":19506,"parent":22,"slug":"avocado","name":"Avocado","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":25,"parent":22,"slug":"dinner","name":"Dinner","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":27,"parent":22,"slug":"fish","name":"Fish and Seafood","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":19549,"parent":22,"slug":"lime","name":"Lime","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":23,"parent":22,"slug":"lunch","name":"Lunch","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":6,"parent":22,"slug":"main-dishes","name":"Main Dishes","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":30,"parent":22,"slug":"popular","name":"Most Popular","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":42,"parent":22,"slug":"quick-and-easy","name":"Quick and Easy","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":10982,"parent":22,"slug":"sugar-free","name":"Sugar-Free","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":19529,"parent":22,"slug":"summer","name":"Summer","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]},{"@id":19516,"parent":22,"slug":"taco","name":"Tacos","parents":[{"@type":"CategoryParent","@id":22,"slug":"recipes","name":"Recipes"}]}]}]}</script>
+<!-- [slickstream] END Page Metadata -->
+<!-- [slickstream] WP-Rocket Detection -->
+<script id="slick-wp-rocket-detect-script" class='slickstream-script'>
+(function() {
+    const slickScripts = document.querySelectorAll('script.slickstream-script[type=rocketlazyloadscript]');
+    const extScripts = document.querySelectorAll('script[type=rocketlazyloadscript][src*="app.slickstream.com"]');
+    if (slickScripts.length > 0 || extScripts.length > 0) {
+        console.warn('[slickstream]' + ['Slickstream scripts. This ',
+        'may cause undesirable behavior, ', 'such as increased CLS scores.',' WP-Rocket is deferring one or more '].sort().join(''));
+    }
+})();
+</script><!-- [slickstream] END WP-Rocket Detection -->
+<!-- [slickstream] [[[ END Slickstream Output ]]] -->
+
+
+<link rel="icon" href="https://pinchofyum.com/tachyon/cropped-Pinch-of-Yum-Favicon-512.png?fit=32%2C32" sizes="32x32" />
+<link rel="icon" href="https://pinchofyum.com/tachyon/cropped-Pinch-of-Yum-Favicon-512.png?fit=192%2C192" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://pinchofyum.com/tachyon/cropped-Pinch-of-Yum-Favicon-512.png?fit=180%2C180" />
+<meta name="msapplication-TileImage" content="https://pinchofyum.com/tachyon/cropped-Pinch-of-Yum-Favicon-512.png?fit=270%2C270" />
+<style id="wp-custom-css">
+body .is-layout-flex.are-vertically-aligned-top {
+	align-items: flex-start;
+}
+
+.entry-content .recipe-step ul {
+	text-align: left;
+	border: none;
+}
+
+.entry-content .recipe-step ul li:before {
+	background-color: #000;
+}
+
+.recipe-collection .entry-content ul.collection-toc li {
+	padding-top: 0.675em;
+}
+</style>
+	<script async id="ebx" src="//applets.ebxcdn.com/ebx.js"></script>
+	<style id="wp-block-heading-inline-css">
+h1:where(.wp-block-heading).has-background,h2:where(.wp-block-heading).has-background,h3:where(.wp-block-heading).has-background,h4:where(.wp-block-heading).has-background,h5:where(.wp-block-heading).has-background,h6:where(.wp-block-heading).has-background{padding:1.25em 2.375em}h1.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h1.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h2.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h2.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h3.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h3.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h4.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h4.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h5.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h5.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]),h6.has-text-align-left[style*=writing-mode]:where([style*=vertical-lr]),h6.has-text-align-right[style*=writing-mode]:where([style*=vertical-rl]){rotate:180deg}
+/*# sourceURL=https://pinchofyum.com/wp-includes/blocks/heading/style.min.css */
+</style>
+<style id="wp-block-image-inline-css">
+.wp-block-image>a,.wp-block-image>figure>a{display:inline-block}.wp-block-image img{box-sizing:border-box;height:auto;max-width:100%;vertical-align:bottom}@media not (prefers-reduced-motion){.wp-block-image img.hide{visibility:hidden}.wp-block-image img.show{animation:show-content-image .4s}}.wp-block-image[style*=border-radius] img,.wp-block-image[style*=border-radius]>a{border-radius:inherit}.wp-block-image.has-custom-border img{box-sizing:border-box}.wp-block-image.aligncenter{text-align:center}.wp-block-image.alignfull>a,.wp-block-image.alignwide>a{width:100%}.wp-block-image.alignfull img,.wp-block-image.alignwide img{height:auto;width:100%}.wp-block-image .aligncenter,.wp-block-image .alignleft,.wp-block-image .alignright,.wp-block-image.aligncenter,.wp-block-image.alignleft,.wp-block-image.alignright{display:table}.wp-block-image .aligncenter>figcaption,.wp-block-image .alignleft>figcaption,.wp-block-image .alignright>figcaption,.wp-block-image.aligncenter>figcaption,.wp-block-image.alignleft>figcaption,.wp-block-image.alignright>figcaption{caption-side:bottom;display:table-caption}.wp-block-image .alignleft{float:left;margin:.5em 1em .5em 0}.wp-block-image .alignright{float:right;margin:.5em 0 .5em 1em}.wp-block-image .aligncenter{margin-left:auto;margin-right:auto}.wp-block-image :where(figcaption){margin-bottom:1em;margin-top:.5em}.wp-block-image.is-style-circle-mask img{border-radius:9999px}@supports ((-webkit-mask-image:none) or (mask-image:none)) or (-webkit-mask-image:none){.wp-block-image.is-style-circle-mask img{border-radius:0;-webkit-mask-image:url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>');mask-image:url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>');mask-mode:alpha;-webkit-mask-position:center;mask-position:center;-webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;-webkit-mask-size:contain;mask-size:contain}}:root :where(.wp-block-image.is-style-rounded img,.wp-block-image .is-style-rounded img){border-radius:9999px}.wp-block-image figure{margin:0}.wp-lightbox-container{display:flex;flex-direction:column;position:relative}.wp-lightbox-container img{cursor:zoom-in}.wp-lightbox-container img:hover+button{opacity:1}.wp-lightbox-container button{align-items:center;backdrop-filter:blur(16px) saturate(180%);background-color:#5a5a5a40;border:none;border-radius:4px;cursor:zoom-in;display:flex;height:20px;justify-content:center;opacity:0;padding:0;position:absolute;right:16px;text-align:center;top:16px;width:20px;z-index:100}@media not (prefers-reduced-motion){.wp-lightbox-container button{transition:opacity .2s ease}}.wp-lightbox-container button:focus-visible{outline:3px auto #5a5a5a40;outline:3px auto -webkit-focus-ring-color;outline-offset:3px}.wp-lightbox-container button:hover{cursor:pointer;opacity:1}.wp-lightbox-container button:focus{opacity:1}.wp-lightbox-container button:focus,.wp-lightbox-container button:hover,.wp-lightbox-container button:not(:hover):not(:active):not(.has-background){background-color:#5a5a5a40;border:none}.wp-lightbox-overlay{box-sizing:border-box;cursor:zoom-out;height:100vh;left:0;overflow:hidden;position:fixed;top:0;visibility:hidden;width:100%;z-index:100000}.wp-lightbox-overlay .wp-lightbox-close-button{align-items:center;cursor:pointer;display:flex;font-family:inherit;gap:8px;justify-content:center;line-height:1;min-height:40px;min-width:40px;padding:0 4px;position:absolute;right:calc(env(safe-area-inset-right) + 16px);top:calc(env(safe-area-inset-top) + 16px);z-index:5000000}.wp-lightbox-overlay .wp-lightbox-close-button:focus,.wp-lightbox-overlay .wp-lightbox-close-button:hover,.wp-lightbox-overlay .wp-lightbox-close-button:not(:hover):not(:active):not(.has-background){background:none;border:none}.wp-lightbox-overlay .wp-lightbox-close-button:has(.wp-lightbox-close-text:not([hidden])) .wp-lightbox-close-icon svg{height:1em;width:1em}.wp-lightbox-overlay .wp-lightbox-close-icon svg{display:block}.wp-lightbox-overlay .wp-lightbox-navigation-button-next,.wp-lightbox-overlay .wp-lightbox-navigation-button-prev{align-items:center;bottom:16px;cursor:pointer;display:flex;font-family:inherit;gap:4px;justify-content:center;line-height:1;min-height:40px;min-width:40px;padding:0 8px;position:absolute;z-index:2000002}.wp-lightbox-overlay .wp-lightbox-navigation-button-next[hidden],.wp-lightbox-overlay .wp-lightbox-navigation-button-prev[hidden]{display:none}@media (min-width:960px){.wp-lightbox-overlay .wp-lightbox-navigation-button-next,.wp-lightbox-overlay .wp-lightbox-navigation-button-prev{bottom:50%;transform:translateY(-50%)}}.wp-lightbox-overlay .wp-lightbox-navigation-button-next:focus,.wp-lightbox-overlay .wp-lightbox-navigation-button-next:hover,.wp-lightbox-overlay .wp-lightbox-navigation-button-next:not(:hover):not(:active):not(.has-background),.wp-lightbox-overlay .wp-lightbox-navigation-button-prev:focus,.wp-lightbox-overlay .wp-lightbox-navigation-button-prev:hover,.wp-lightbox-overlay .wp-lightbox-navigation-button-prev:not(:hover):not(:active):not(.has-background){background:none;border:none;padding:0 8px}.wp-lightbox-overlay .wp-lightbox-navigation-button-next:has(.wp-lightbox-navigation-text:not([hidden])) .wp-lightbox-navigation-icon svg,.wp-lightbox-overlay .wp-lightbox-navigation-button-prev:has(.wp-lightbox-navigation-text:not([hidden])) .wp-lightbox-navigation-icon svg{display:block;height:1.5em;width:1.5em}.wp-lightbox-overlay .wp-lightbox-navigation-button-prev{left:calc(env(safe-area-inset-left) + 16px)}.wp-lightbox-overlay .wp-lightbox-navigation-button-next{right:calc(env(safe-area-inset-right) + 16px)}.wp-lightbox-overlay .wp-lightbox-navigation-icon svg{vertical-align:middle}.wp-lightbox-overlay .lightbox-image-container{height:var(--wp--lightbox-container-height);left:50%;overflow:hidden;position:absolute;top:50%;transform:translate(-50%,-50%);transform-origin:top left;width:var(--wp--lightbox-container-width);z-index:2000001}.wp-lightbox-overlay .wp-block-image{align-items:center;box-sizing:border-box;display:flex;height:100%;justify-content:center;margin:0;position:relative;transform-origin:0 0;width:100%;z-index:3000000}.wp-lightbox-overlay .wp-block-image img{height:var(--wp--lightbox-image-height);min-height:var(--wp--lightbox-image-height);min-width:var(--wp--lightbox-image-width);width:var(--wp--lightbox-image-width)}.wp-lightbox-overlay .wp-block-image figcaption{display:none}.wp-lightbox-overlay button{background:none;border:none}.wp-lightbox-overlay .scrim{background-color:#fff;height:100%;opacity:.9;position:absolute;width:100%;z-index:2000000}.wp-lightbox-overlay.active{visibility:visible}@media not (prefers-reduced-motion){.wp-lightbox-overlay.active{animation:turn-on-visibility .25s both}.wp-lightbox-overlay.active img{animation:turn-on-visibility .35s both}.wp-lightbox-overlay.show-closing-animation:not(.active){animation:turn-off-visibility .35s both}.wp-lightbox-overlay.show-closing-animation:not(.active) img{animation:turn-off-visibility .25s both}.wp-lightbox-overlay.zoom.active{animation:none;opacity:1;visibility:visible}.wp-lightbox-overlay.zoom.active .lightbox-image-container{animation:lightbox-zoom-in .4s}.wp-lightbox-overlay.zoom.active .lightbox-image-container img{animation:none}.wp-lightbox-overlay.zoom.active .scrim{animation:turn-on-visibility .4s forwards}.wp-lightbox-overlay.zoom.show-closing-animation:not(.active){animation:none}.wp-lightbox-overlay.zoom.show-closing-animation:not(.active) .lightbox-image-container{animation:lightbox-zoom-out .4s}.wp-lightbox-overlay.zoom.show-closing-animation:not(.active) .lightbox-image-container img{animation:none}.wp-lightbox-overlay.zoom.show-closing-animation:not(.active) .scrim{animation:turn-off-visibility .4s forwards}}@keyframes show-content-image{0%{visibility:hidden}99%{visibility:hidden}to{visibility:visible}}@keyframes turn-on-visibility{0%{opacity:0}to{opacity:1}}@keyframes turn-off-visibility{0%{opacity:1;visibility:visible}99%{opacity:0;visibility:visible}to{opacity:0;visibility:hidden}}@keyframes lightbox-zoom-in{0%{transform:translate(calc((-100vw + var(--wp--lightbox-scrollbar-width))/2 + var(--wp--lightbox-initial-left-position)),calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale))}to{transform:translate(-50%,-50%) scale(1)}}@keyframes lightbox-zoom-out{0%{transform:translate(-50%,-50%) scale(1);visibility:visible}99%{visibility:visible}to{transform:translate(calc((-100vw + var(--wp--lightbox-scrollbar-width))/2 + var(--wp--lightbox-initial-left-position)),calc(-50vh + var(--wp--lightbox-initial-top-position))) scale(var(--wp--lightbox-scale));visibility:hidden}}
+/*# sourceURL=https://pinchofyum.com/wp-includes/blocks/image/style.min.css */
+</style>
+<style id="wp-block-list-inline-css">
+ol,ul{box-sizing:border-box}:root :where(.wp-block-list.has-background){padding:1.25em 2.375em}
+/*# sourceURL=https://pinchofyum.com/wp-includes/blocks/list/style.min.css */
+</style>
+<style id="wp-block-paragraph-inline-css">
+.is-small-text{font-size:.875em}.is-regular-text{font-size:1em}.is-large-text{font-size:2.25em}.is-larger-text{font-size:3em}.has-drop-cap:not(:focus):first-letter{float:left;font-size:8.4em;font-style:normal;font-weight:100;line-height:.68;margin:.05em .1em 0 0;text-transform:uppercase}body.rtl .has-drop-cap:not(:focus):first-letter{float:none;margin-left:.1em}p.has-drop-cap.has-background{overflow:hidden}:root :where(p.has-background){padding:1.25em 2.375em}:where(p.has-text-color:not(.has-link-color)) a{color:inherit}p.has-text-align-left[style*="writing-mode:vertical-lr"],p.has-text-align-right[style*="writing-mode:vertical-rl"]{rotate:180deg}
+/*# sourceURL=https://pinchofyum.com/wp-includes/blocks/paragraph/style.min.css */
+</style>
+<style id="wp-block-separator-inline-css">
+@charset "UTF-8";.wp-block-separator{border:none;border-top:2px solid}:root :where(.wp-block-separator.is-style-dots){height:auto;line-height:1;text-align:center}:root :where(.wp-block-separator.is-style-dots):before{color:currentColor;content:"···";font-family:serif;font-size:1.5em;letter-spacing:2em;padding-left:2em}.wp-block-separator.is-style-dots{background:none!important;border:none!important}
+/*# sourceURL=https://pinchofyum.com/wp-includes/blocks/separator/style.min.css */
+</style>
+<link rel='stylesheet' id='tasty-recipes-pro-main-css' href='https://pinchofyum.com/content/plugins/tasty-recipes/assets/dist/recipe.css?ver=4.0.4' media='all' />
+
+</head>
+
+<body class="wp-singular post-template-default single single-post postid-23546 single-format-standard wp-theme-pinchofyum-2020 adthrive-cat-all adthrive-cat-avocado adthrive-cat-dinner adthrive-cat-fish adthrive-cat-lime adthrive-cat-lunch adthrive-cat-main-dishes adthrive-cat-popular adthrive-cat-quick-and-easy adthrive-cat-sugar-free adthrive-cat-summer adthrive-cat-taco">
+	<script>
+	//Font Face Observer for loading Drama swaps
+	(function() {
+		var font = new FontFaceObserver('Drama Regular');
+		font.load().then(function () {
+			document.querySelector('body').classList.add('font-drama-loaded');
+		});
+	})()
+	</script>
+
+		<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WZ4GRNV" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+	
+	<div style="height: 0; width: 0; position: absolute; visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg"><symbol id="sprite-icon-arrow" viewBox="0 0 10.7 10.7"><title>icon-arrow</title><path fill="#734060" d="m10.7 5.3-5.4 5.4L0 5.3l1-.9 3.7 3.7V0H6v8.1l3.8-3.7z"/></symbol><symbol id="sprite-icon-chevron-white" viewBox="0 0 5.9 9.5"><title>icon-chevron-white</title><g data-name="Layer 2"><g data-name="Layer 1"><g data-name="Layer 2"><path d="m0 8.4 3.6-3.6L0 1.1 1.1 0l4.8 4.8-4.8 4.7Z" data-name="Layer 1-2" style="fill:#fff"/></g></g></g></symbol><symbol id="sprite-icon-chevron" viewBox="0 0 5.9 9.5"><title>icon-chevron</title><g data-name="Layer 2"><path fill="currentColor" d="m0 8.4 3.6-3.6L0 1.1 1.1 0l4.8 4.8-4.8 4.7Z" data-name="Layer 1"/></g></symbol><symbol id="sprite-icon-comment" viewBox="0 0 13.3 13.3"><title>icon-comment</title><g data-name="Layer 2"><path d="M13.3 1.3v12l-2.6-2.6H1.3a1.4 1.4 0 0 1-.9-.5 1 1 0 0 1-.4-.9v-8A1.2 1.2 0 0 1 .4.4a1.2 1.2 0 0 1 .9-.4H12a1 1 0 0 1 .9.4 1.2 1.2 0 0 1 .4.9M10.7 4V2.7h-8V4Zm0 2V4.7h-8V6Zm0 2V6.7h-8V8Z" data-name="Layer 1" style="fill:#734060"/></g></symbol><symbol id="sprite-icon-facebook" viewBox="0 0 320 512"><title>icon-facebook</title><path fill="currentColor" d="m279.1 288 14.2-92.7h-88.9v-60.1c0-25.3 12.4-50.1 52.2-50.1H297V6.3S260.3 0 225.3 0c-73.2 0-121.1 44.4-121.1 124.7v70.6H22.9V288h81.4v224h100.2V288z"/></symbol><symbol id="sprite-icon-heart" viewBox="0 0 28.4 24.8"><title>icon-heart</title><g data-name="Layer 2"><path d="M26.2 2.2A7.5 7.5 0 0 0 20.9 0a7.9 7.9 0 0 0-5.4 2.2l-1.3 1.4-1.3-1.4a7.6 7.6 0 0 0-10.7 0 7.8 7.8 0 0 0 0 10.8l11.7 11.7h.7L26.2 13a7.6 7.6 0 0 0 0-10.8m-.7 10.1L14.2 23.7 2.9 12.3a6.6 6.6 0 0 1 0-9.4A6.2 6.2 0 0 1 7.5 1a6.3 6.3 0 0 1 4.7 1.9l1.7 1.7h.7l1.6-1.7A6.4 6.4 0 0 1 20.9 1a6.6 6.6 0 0 1 4.7 1.9 6.7 6.7 0 0 1-.1 9.4" data-name="Layer 1" style="fill:#ebb454"/></g></symbol><symbol id="sprite-icon-instagram" viewBox="0 0 448 512"><title>icon-instagram</title><path fill="currentColor" d="M224.1 141c-63.6 0-114.9 51.3-114.9 114.9s51.3 114.9 114.9 114.9S339 319.5 339 255.9 287.7 141 224.1 141m0 189.6c-41.1 0-74.7-33.5-74.7-74.7s33.5-74.7 74.7-74.7 74.7 33.5 74.7 74.7-33.6 74.7-74.7 74.7m146.4-194.3c0 14.9-12 26.8-26.8 26.8-14.9 0-26.8-12-26.8-26.8s12-26.8 26.8-26.8 26.8 12 26.8 26.8m76.1 27.2c-1.7-35.9-9.9-67.7-36.2-93.9-26.2-26.2-58-34.4-93.9-36.2-37-2.1-147.9-2.1-184.9 0-35.8 1.7-67.6 9.9-93.9 36.1s-34.4 58-36.2 93.9c-2.1 37-2.1 147.9 0 184.9 1.7 35.9 9.9 67.7 36.2 93.9s58 34.4 93.9 36.2c37 2.1 147.9 2.1 184.9 0 35.9-1.7 67.7-9.9 93.9-36.2 26.2-26.2 34.4-58 36.2-93.9 2.1-37 2.1-147.8 0-184.8M398.8 388c-7.8 19.6-22.9 34.7-42.6 42.6-29.5 11.7-99.5 9-132.1 9s-102.7 2.6-132.1-9c-19.6-7.8-34.7-22.9-42.6-42.6-11.7-29.5-9-99.5-9-132.1s-2.6-102.7 9-132.1c7.8-19.6 22.9-34.7 42.6-42.6 29.5-11.7 99.5-9 132.1-9s102.7-2.6 132.1 9c19.6 7.8 34.7 22.9 42.6 42.6 11.7 29.5 9 99.5 9 132.1s2.7 102.7-9 132.1"/></symbol><symbol id="sprite-icon-instant-pot" viewBox="0 0 41 43"><title>icon-instant-pot</title><g data-name="Layer 2"><path fill="currentColor" d="M3.6 11.4h.1a.7.7 0 0 0 .7-.6.6.6 0 0 0-.6-.8 1.1 1.1 0 0 1-.6-.4c-.1-.3-.3-1.2 1.1-3.3s1.9-3.9 1.5-5A2.4 2.4 0 0 0 4.6 0a.7.7 0 0 0-.9.5.8.8 0 0 0 .4.9c.1 0 .2.1.3.4s.2 1.4-1.3 3.7-1.7 3.6-1.2 4.7a2 2 0 0 0 1.7 1.2m4.6-3.2h.1a.7.7 0 0 0 .7-.6.8.8 0 0 0-.7-.8s-.2-.4.6-1.6 1.2-2.4.9-3.2a1.4 1.4 0 0 0-.9-.8.7.7 0 0 0-.9.4.6.6 0 0 0 .4.9c0 .1.2.6-.7 1.9s-1 2.3-.7 3a1.3 1.3 0 0 0 1.2.8m32 11.4a10.6 10.6 0 0 0-5.4 1.5v-2a.7.7 0 0 0-.7-.7H6.9a.7.7 0 0 0-.7.7v2a11 11 0 0 0-5.5-1.5.8.8 0 0 0-.7.7.7.7 0 0 0 .7.7 8.4 8.4 0 0 1 5.5 1.9v13.5a6.7 6.7 0 0 0 6.6 6.6h15.4a6.7 6.7 0 0 0 6.6-6.6V22.9a8.1 8.1 0 0 1 5.5-1.9.7.7 0 0 0 .7-.7.8.8 0 0 0-.8-.7m-6.8 16.8a5.2 5.2 0 0 1-5.2 5.1H12.8a5.1 5.1 0 0 1-5.2-5.1V19.8h25.8ZM7.3 11.9l10.1 1.5 7.4 1.1 9.2 1.4h.1a.9.9 0 0 0 .7-.6.9.9 0 0 0-.6-.9l-8.6-1.2a3.7 3.7 0 0 0-1.1-2.7 4.6 4.6 0 0 0-7.5 1.4l-9.5-1.4c-.4-.1-.7.2-.8.6s.2.8.6.8m13.9-1.4a3.4 3.4 0 0 1 2.3 1 3.5 3.5 0 0 1 .7 1.5l-5.7-.9a2.9 2.9 0 0 1 2.7-1.6" data-name="Layer 1"/></g></symbol><symbol id="sprite-icon-list" viewBox="0 0 32.2 41.6"><title>icon-list</title><g data-name="Layer 2"><g data-name="Layer 1"><path d="M25.9 33.3H7.7a.7.7 0 0 0 0 1.4h18.2a.7.7 0 0 0 0-1.4m0-5.6H7.7a.7.7 0 0 0-.7.6.7.7 0 0 0 .7.7h18.2a.7.7 0 0 0 .7-.7.7.7 0 0 0-.7-.6m0-5.7H7.7a.7.7 0 1 0 0 1.4h18.2a.7.7 0 0 0 0-1.4M7.7 17.9H16a.7.7 0 1 0 0-1.4H7.7a.7.7 0 1 0 0 1.4" style="fill:#ebb454"/><path d="M31.5 2.5h-6.3V.7a.7.7 0 0 0-1.4 0v1.8h-7.1V.7a.7.7 0 0 0-1.4 0v1.8H8.4V.7A.7.7 0 0 0 7 .7v1.8H.7a.7.7 0 0 0-.7.7v37.7a.7.7 0 0 0 .7.7h30.8a.8.8 0 0 0 .7-.7V3.2a.8.8 0 0 0-.7-.7m-.7 37.7H1.4V3.9H7v2.8a2.8 2.8 0 0 0-2.1 2.6 2.9 2.9 0 0 0 2.8 2.8 2.8 2.8 0 0 0 .7-5.4V3.9h6.9v2.8a2.8 2.8 0 0 0 .7 5.4 2.8 2.8 0 0 0 2.7-2.8 2.7 2.7 0 0 0-2-2.6V3.9h7.1v2.8a2.8 2.8 0 0 0 .7 5.4 2.9 2.9 0 0 0 2.8-2.8 2.8 2.8 0 0 0-2.1-2.6V3.9h5.6ZM7 8.2a.7.7 0 0 0 .7.6.6.6 0 0 0 .6-.6 1.4 1.4 0 1 1-1.3 0m8.4 0a.6.6 0 0 0 .6.6.9.9 0 0 0 .7-.6 1.4 1.4 0 0 1 .6 1.1 1.3 1.3 0 1 1-2.6 0 1.2 1.2 0 0 1 .7-1.1m8.5 0a.6.6 0 0 0 .6.6.7.7 0 0 0 .7-.6 1.4 1.4 0 1 1-1.3 0" style="fill:#ebb454"/></g></g></symbol><symbol id="sprite-icon-lock" viewBox="0 0 8 10.5"><title>icon-lock</title><g data-name="Layer 2"><path d="M7 3.5a.9.9 0 0 1 .7.3.9.9 0 0 1 .3.7v5a1 1 0 0 1-1 1H1a.9.9 0 0 1-.7-.3.9.9 0 0 1-.3-.7v-5a.9.9 0 0 1 .3-.7.9.9 0 0 1 .7-.3h.5v-1A2.4 2.4 0 0 1 4 0a2.4 2.4 0 0 1 2.5 2.5v1Zm-1.4 0v-1a1.6 1.6 0 0 0-.5-1.1A1.5 1.5 0 0 0 4 1a1.5 1.5 0 0 0-1.1.4 1.5 1.5 0 0 0-.4 1.1v1ZM3.3 7.7A.9.9 0 0 0 4 8a.9.9 0 0 0 .7-.3 1 1 0 0 0 0-1.4A.9.9 0 0 0 4 6a.9.9 0 0 0-.7.3 1 1 0 0 0 0 1.4" data-name="Layer 1" style="fill:#d1b7ca"/></g></symbol><symbol id="sprite-icon-meal-prep" viewBox="0 0 38.8 40.7"><title>icon-meal-prep</title><g data-name="Layer 2"><g fill="currentColor" data-name="Layer 1"><path d="M38.2 35.3H.7a.7.7 0 0 0-.7.7.7.7 0 0 0 .7.6H2l1.9 3.7c.2.2.4.4.6.4h29.6a.7.7 0 0 0 .6-.4l2-3.7h1.5a.6.6 0 0 0 .6-.6.7.7 0 0 0-.6-.7m-4.5 4H5l-1.5-2.7h31.6ZM2.4 33.8h33.9a.7.7 0 0 0 .7-.7c0-10.5-7.5-18.2-17.7-18.2S1.7 22.6 1.7 33.1a.7.7 0 0 0 .7.7m16.9-17.5c9.2 0 16 6.7 16.3 16.2H3.1c.3-9.5 7-16.2 16.2-16.2m-2-1.9a.8.8 0 0 0 .7-.7c0-1.8 1.5-2.1 2.2-1.4a2 2 0 0 1 .4 1.4.8.8 0 0 0 .7.7.8.8 0 0 0 .7-.7c0-4.1-5.4-4.1-5.4 0a.8.8 0 0 0 .7.7"/><path d="M14.6 19.9c-3.6 1.5-5.9 4.5-7.2 8.9a.8.8 0 0 0 .4.9H8a.8.8 0 0 0 .7-.5c1.2-4 3.3-6.7 6.4-8a.7.7 0 1 0-.5-1.3m4.7-12a.7.7 0 0 0 .7-.6V.7a.7.7 0 1 0-1.4 0v6.6a.7.7 0 0 0 .7.6m9.8 4.1a.6.6 0 0 0 .5-.2l5-5.3a.7.7 0 0 0 0-1 .8.8 0 0 0-1 .1l-5 5.3a.6.6 0 0 0 0 .9c.1.2.3.2.5.2m-20-.2c.1.2.3.2.5.2a.6.6 0 0 0 .5-.2.7.7 0 0 0 0-.9L5 5.6a.6.6 0 0 0-.9-.1.8.8 0 0 0-.1 1Z"/></g></g></symbol><symbol id="sprite-icon-next" viewBox="0 0 17.7 17.7"><title>icon-next</title><g data-name="Layer 2"><g fill="currentColor" stroke="currentColor" data-name="Layer 1"><path d="M8.8.5A8.3 8.3 0 0 0 .5 8.8a8.4 8.4 0 0 0 8.3 8.4 8.5 8.5 0 0 0 8.4-8.4A8.4 8.4 0 0 0 8.8.5Zm0 16.1a7.8 7.8 0 1 1 7.8-7.8 7.8 7.8 0 0 1-7.8 7.8Z"/><path d="M13.2 9h-.1L9.7 5.5h-.4a.3.3 0 0 0 0 .4l2.9 2.9H4.7a.3.3 0 0 0 0 .6h7.5l-2.9 2.9a.3.3 0 0 0 0 .4h.4l3.4-3.4a.1.1 0 0 1 .1-.1Z"/></g></g></symbol><symbol id="sprite-icon-pinterest" viewBox="0 0 384 512"><title>icon-pinterest</title><path fill="currentColor" d="M204 6.5C101.4 6.5 0 74.9 0 185.6 0 256 39.6 296 63.6 296c9.9 0 15.6-27.6 15.6-35.4 0-9.3-23.7-29.1-23.7-67.8 0-80.4 61.2-137.4 140.4-137.4 68.1 0 118.5 38.7 118.5 109.8 0 53.1-21.3 152.7-90.3 152.7-24.9 0-46.2-18-46.2-43.8 0-37.8 26.4-74.4 26.4-113.4 0-66.2-93.9-54.2-93.9 25.8 0 16.8 2.1 35.4 9.6 50.7-13.8 59.4-42 147.9-42 209.1 0 18.9 2.7 37.5 4.5 56.4 3.4 3.8 1.7 3.4 6.9 1.5 50.4-69 48.6-82.5 71.4-172.8 12.3 23.4 44.1 36 69.3 36 106.2 0 153.9-103.5 153.9-196.8C384 71.3 298.2 6.5 204 6.5"/></symbol><symbol id="sprite-icon-popular" viewBox="0 0 36.2 39.7"><title>icon-popular</title><g data-name="Layer 2"><g fill="currentColor" data-name="Layer 1"><path d="M24.1 34.8a.8.8 0 0 0-.7-.4h-2.7v-5.9a.7.7 0 0 0-.6-.7.7.7 0 0 0-.7.7v5.9h-2.6v-5.9a.7.7 0 0 0-.7-.7.7.7 0 0 0-.6.7v5.9h-2.7a.8.8 0 0 0-.7.4l-1 4a.5.5 0 0 0 .1.6.5.5 0 0 0 .5.3h12.8a.7.7 0 0 0 .7-.7c0-.1-.1-.2-.1-.3Zm-11.5 3.5.7-2.6h9.6l.7 2.6ZM31.9 4.7a4.1 4.1 0 0 0-1.9-.1V1.8A1.9 1.9 0 0 0 28.1 0h-20a1.8 1.8 0 0 0-1.9 1.8v2.8a4.1 4.1 0 0 0-1.9.1c-3.3.9-5.1 5-4 9.1a8.2 8.2 0 0 0 3.8 5.3 5 5 0 0 0 2.8.8h.8a11.8 11.8 0 0 0 10.4 6.6 11.8 11.8 0 0 0 10.4-6.6h.8a4.7 4.7 0 0 0 2.7-.8 8.4 8.4 0 0 0 3.9-5.3c1-4.1-.7-8.2-4-9.1M4.8 18a7.3 7.3 0 0 1-3.2-4.5C.7 10 2 6.7 4.6 6h1.6v7.7a13.3 13.3 0 0 0 .9 4.9 4.9 4.9 0 0 1-2.3-.6m13.3 7.2c-5.8 0-10.6-5.2-10.6-11.5V1.8a.6.6 0 0 1 .6-.5h20a.5.5 0 0 1 .5.5v11.9c0 6.3-4.7 11.5-10.5 11.5m16.5-11.7a7.7 7.7 0 0 1-3.2 4.5 5.3 5.3 0 0 1-2.3.6 15.8 15.8 0 0 0 .9-4.9V6h1.6c2.5.7 3.9 4 3 7.5"/><path d="M21.5 9.4h-1.3l-.3-1c-.8-2.4-1.1-3.1-1.8-3.1s-1 .7-1.7 2.9l-.5 1.2h-1c-2.6 0-3.3 0-3.5.7s.3 1.2 2.2 2.6l1 .8-.3 1c-.7 2.2-.9 2.9-.5 3.4a.7.7 0 0 0 .6.3c.6 0 1.1-.4 2.6-1.4l1.1-.8.9.6c1.6 1.2 2.2 1.6 2.8 1.6a.7.7 0 0 0 .6-.3c.4-.5.2-1.1-.4-3.2a5.6 5.6 0 0 1-.4-1.2l.8-.7c2.1-1.5 2.7-2 2.4-2.7s-.9-.7-3.3-.7m.1 2.3-1.2 1a.6.6 0 0 0-.2.7c.2.6.3 1.2.5 1.7a10 10 0 0 1 .4 1.4l-1.3-1-1.3-.9h-.8l-1.5 1.1-1.1.8.5-1.6.4-1.5a.6.6 0 0 0-.2-.7l-1.5-1.1-1.1-.9h3.2a.6.6 0 0 0 .6-.5 7 7 0 0 0 .6-1.7c.2-.5.3-1 .5-1.4a14 14 0 0 0 .5 1.6l.5 1.5a.8.8 0 0 0 .7.5H23Z"/></g></g></symbol><symbol id="sprite-icon-quote" viewBox="0 0 50.2 34.7"><title>icon-quote</title><g data-name="Layer 2"><path d="M13.5 15.7a8.7 8.7 0 0 1 8.9 9.1c0 5.8-4.3 9.9-10.4 9.9S0 29 0 21.2C0 8 10.4.1 23.6 0v1.9C13.3 3 5.8 8.6 6.6 18.7a8.3 8.3 0 0 1 6.9-3m26.6 0a8.8 8.8 0 0 1 8.9 9.1c0 5.8-4.4 9.9-10.4 9.9s-12-5.7-12-13.5C26.6 8 37 .1 50.2 0v1.9C39.9 3 32.4 8.6 33.1 18.7c1.3-1.8 3.9-3 7-3" data-name="Layer 1" style="fill:#e4e4e4"/></g></symbol><symbol id="sprite-icon-search" viewBox="0 0 18.5 18.5"><title>icon-search</title><g data-name="Layer 2"><path d="m17.2 18.5-4.9-4.9a8.1 8.1 0 0 1-4.7 1.6A7.9 7.9 0 0 1 2.2 13 7.9 7.9 0 0 1 0 7.6a7.9 7.9 0 0 1 2.2-5.4A7.9 7.9 0 0 1 7.6 0 7.9 7.9 0 0 1 13 2.2a7.9 7.9 0 0 1 2.2 5.4 8.1 8.1 0 0 1-1.6 4.7l4.9 4.9Zm-9.6-5.2a6.2 6.2 0 0 0 4.1-1.6 6.2 6.2 0 0 0 1.6-4.1 6.2 6.2 0 0 0-1.6-4.1 5.8 5.8 0 1 0-8.2 8.2 6.2 6.2 0 0 0 4.1 1.6" data-name="Layer 1" style="fill:#734060"/></g></symbol><symbol id="sprite-icon-star" viewBox="0 0 3000 3000"><title>icon-star</title><path d="m1936.76 1040.24 976.87 141.45-706.47 689.33 167.35 972.76-873.9-458.88-873.44 459.76 166.37-972.93-707.17-688.62 976.72-142.42 436.39-885.35z" style="stroke-width:0;fill:#6c435d"/></symbol><symbol id="sprite-icon-sugar-free" viewBox="0 0 42.9 40.3"><title>icon-sugar-free</title><g data-name="Layer 2"><g fill="currentColor" data-name="Layer 1"><path d="M41.8 22.8H27.7l-2.3-5.1c-.1-.3-.4-.4-.8-.4s-.5.3-.6.6l-2.1 10.2-3.8-16.6a.8.8 0 0 0-.7-.5.7.7 0 0 0-.7.5l-3 11.3H1a.7.7 0 0 0-.7.7.8.8 0 0 0 .7.8h13.2a.7.7 0 0 0 .7-.6l2.4-9 4 16.9a.7.7 0 0 0 .7.5.8.8 0 0 0 .7-.5L25 20.4l1.5 3.4a.8.8 0 0 0 .7.5h14.6a.9.9 0 0 0 .8-.8.8.8 0 0 0-.8-.7"/><path d="M3.8 19.9a.7.7 0 0 0 .1-1 10.6 10.6 0 0 1-2.5-6.8A10.7 10.7 0 0 1 12 1.4a11.4 11.4 0 0 1 8.9 4.4.5.5 0 0 0 .5.3.6.6 0 0 0 .6-.3 11.4 11.4 0 0 1 8.9-4.4 10.6 10.6 0 0 1 10.5 10.7 10.5 10.5 0 0 1-2.4 6.8.7.7 0 0 0 .1 1l.4.2a.9.9 0 0 0 .6-.3A12.1 12.1 0 0 0 30.9 0a12.8 12.8 0 0 0-9.5 4.3A12.4 12.4 0 0 0 12 0a12.1 12.1 0 0 0-9.2 19.8.7.7 0 0 0 1 .1m28.7 6.4L22.1 38.4a1 1 0 0 1-.9.4.9.9 0 0 1-.8-.4L10.2 26.3a.7.7 0 0 0-1 0 .7.7 0 0 0-.1 1l10.2 12a2.4 2.4 0 0 0 1.9 1 2.9 2.9 0 0 0 2-.9l10.4-12.1a.7.7 0 0 0 0-1 .8.8 0 0 0-1.1 0"/></g></g></symbol><symbol id="sprite-icon-tiktok" viewBox="0 0 448 512"><title>icon-tiktok</title><!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path fill="currentColor" d="M448 209.9a210.1 210.1 0 0 1-122.8-39.3v178.8A162.6 162.6 0 1 1 185 188.3v89.9a74.6 74.6 0 1 0 52.2 71.2V0h88a121 121 0 0 0 1.9 22.2 122.2 122.2 0 0 0 53.9 80.2 121.4 121.4 0 0 0 67 20.1z"/></symbol><symbol id="sprite-icon-twitter" viewBox="0 0 512 512"><title>icon-twitter</title><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path fill="currentColor" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8l164.9-188.5L26.8 48h145.6l100.5 132.9zm-24.8 373.8h39.1L151.1 88h-42z"/></symbol><symbol id="sprite-icon-vegan" viewBox="0 0 40.8 40.6"><title>icon-vegan</title><g data-name="Layer 2"><g fill="currentColor" data-name="Layer 1"><path d="m40.6 21.8-.5-.2H.7l-.5.2a.6.6 0 0 0-.2.5c.6 6.9 5.8 13.2 13.4 16.2v1.4a.7.7 0 0 0 .7.7h12.6a.7.7 0 0 0 .7-.7v-1.4c7.6-3 12.8-9.3 13.4-16.2a.6.6 0 0 0-.2-.5M26.5 37.4a.8.8 0 0 0-.5.7v1.1H14.8v-1.1a.8.8 0 0 0-.5-.7c-7-2.7-12-8.3-12.9-14.4h38c-.9 6.1-5.9 11.7-12.9 14.4M3 19.5a1.1 1.1 0 0 0 .7.8H4a.7.7 0 0 0 .6-.3.6.6 0 0 0-.3-.9s-.1-.3.5-1.2a.8.8 0 0 0-.1-.8c-.4-.4-1.4-1.8-1.1-2.8a2.2 2.2 0 0 1 1.6-1 .8.8 0 0 0 .5-.7c-.1-1.2.1-4.4 1.6-5.3s1.8-.2 3.2.6h.6s1.8-.8 2.9-.1a3.3 3.3 0 0 1 1.1 2.9.6.6 0 0 0 .6.6c.6.1 2 .5 2.2 1.1s-.2 1.2-.6 1.7a3.2 3.2 0 0 0-.9 2.9 2.6 2.6 0 0 0 2 1.6c1.1.4 1.4.5 1.6 1.2a.6.6 0 0 0 .8.5.7.7 0 0 0 .5-.8 2.4 2.4 0 0 0-.9-1.4c.1-.8.3-2.2 1-2.5s.8-.2 1.6.1.1 0 .1.1a9.8 9.8 0 0 1 3.1 2.1.7.7 0 0 0 .6.1c.3 0 .4-.2.5-.4s1.7-4.1 3.4-4.3 2.8 1.2 3.7 2.5a.5.5 0 0 0 .4.3h.6c.3-.3.8-.5 1-.4s.1.1.1.6a3.1 3.1 0 0 1-1 2.8.7.7 0 0 0-.2.9.7.7 0 0 0 .6.3h.3c.1 0 1.8-1.1 1.7-3.9a1.9 1.9 0 0 0-1-1.9 2.2 2.2 0 0 0-1.8.2l-1.8-1.8a1.9 1.9 0 0 0 1.3-1.6c.1-.4-.1-1-1-1.6A11.1 11.1 0 0 0 30 8c1-1.6 2.4-4.2 1.9-6.1A2.1 2.1 0 0 0 30.6.3c-2.9-1.4-8.4 2.4-10.3 3.9-.8-1.3-2.4-3.4-3.8-3.5a1.6 1.6 0 0 0-1.1.5c-.5.3-1.8 1.5-1.8 5a5.1 5.1 0 0 0-2.7.4c-1.8-1-3.2-1.1-4.3-.5s-2.3 4.7-2.3 6a3.3 3.3 0 0 0-2 1.8 4.5 4.5 0 0 0 1.1 3.7 2.3 2.3 0 0 0-.4 1.9M16.1 2.3c.1 0 .3-.1.3-.2s2.2 1.8 3.2 3.5l.4.3a.7.7 0 0 0 .6-.2C23.2 3.6 28.1.6 30 1.5a1.2 1.2 0 0 1 .6.8C31 4 28.9 7.4 28 8.5a.8.8 0 0 0 .1 1 .8.8 0 0 0 1-.1c.2-.2 1.8 0 3.8 1.3l.4.3a3.4 3.4 0 0 1-1.5 1 2.9 2.9 0 0 0-1.3-.1c-2.1.3-3.5 2.9-4.1 4.3a13 13 0 0 0-2.6-1.6l-.9-1.8a3.3 3.3 0 0 1 3.2-1.1c.4 0 .8-.2.8-.6a.6.6 0 0 0-.5-.8 4.8 4.8 0 0 0-4 1.1c-.2-1.1-.2-2.2.6-2.7a12.7 12.7 0 0 1 2.2-1.4c1.1-.6 2.1-1.2 1.7-2.5a.6.6 0 0 0-.8-.5.7.7 0 0 0-.5.9c.1.2.1.2-1.1.9l-2.3 1.4a3.1 3.1 0 0 0-1 1.3l-2.9-1.6a.8.8 0 0 0-1 .2.8.8 0 0 0 .3 1l3.3 1.8a9.8 9.8 0 0 0 1.1 3.9l-1.2.2a3.8 3.8 0 0 0-1.7 3.1h-.3c-.4-.1-1-.3-1.1-.7a2.1 2.1 0 0 1 .7-1.7c.9-1.1 1.2-2.1.8-3s-1.9-1.6-2.8-1.8A4.2 4.2 0 0 0 15 6.9c-.2-3.7 1.1-4.6 1.1-4.6"/><path d="M5 15.5a.8.8 0 0 0 .5.9l3.5.9a10.5 10.5 0 0 0 2 2.7.1.1 0 0 0 .1.1h.9v-.2a30.5 30.5 0 0 0 2.1-6.3.8.8 0 0 0-.6-.8c-.4-.1-.7.2-.8.6a38 38 0 0 1-1.5 5 8.7 8.7 0 0 1-2-6.7.6.6 0 0 0-.6-.7.6.6 0 0 0-.7.6 9.9 9.9 0 0 0 .3 4.2l-2.4-.6a.8.8 0 0 0-.8.3m26.5.8a.7.7 0 1 0-.6-1.2c-2.1.9-1.1 4.4-1 4.8h.1v.2h.8a.1.1 0 0 0 .1-.1h.1a24 24 0 0 0 3-2.4.7.7 0 0 0-.1-1 .8.8 0 0 0-1 .1 9.8 9.8 0 0 1-1.9 1.8c-.1-.8-.1-1.9.5-2.2"/></g></g></symbol><symbol id="sprite-icon-video" viewBox="0 0 48 35.3"><title>icon-video</title><g data-name="Layer 2"><g data-name="Layer 1"><path d="m29.5 16.3-7.6-5.5a1.3 1.3 0 0 0-1-.4 1.7 1.7 0 0 0-1.7 1.8v11.1a1.7 1.7 0 0 0 1.7 1.8 1.3 1.3 0 0 0 1-.4l7.6-5.6a1.5 1.5 0 0 0 .7-1.3 1.8 1.8 0 0 0-.7-1.5m-.9 1.6-7.7 5.5s-.1 0-.1-.2v-11c0-.1 0-.2.1-.2h.1l7.6 5.5.5-.6Z" style="fill:#ebb454"/><path d="M43.9 2.3C42.4 1.2 38.8 0 24 0S5.7 1.4 4.8 2C.5 4.5.1 14.8 0 18s.7 12.9 4.8 15.4c.9.5 3.2 1.9 19.2 1.9s18.4-1.2 19.9-2.2c3.5-2.6 4.1-10.6 4.1-15.2S47.6 5 43.9 2.3m-1 29.5c-1.8 1.3-8.1 1.9-18.9 1.9S7.5 33.1 5.6 32s-3.9-8.4-4-14 1.2-13 4-14.7S13.7 1.6 24 1.6s17.1.7 18.9 2 3.5 8.6 3.5 14.3-1.3 12.3-3.5 13.9" style="fill:#ebb454"/></g></g></symbol><symbol id="sprite-icon-youtube" viewBox="0 0 576 512"><title>icon-youtube</title><!--!Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2025 Fonticons, Inc.--><path fill="currentColor" d="M549.7 124.1c-6.3-23.7-24.8-42.3-48.3-48.6C458.8 64 288 64 288 64S117.2 64 74.6 75.5c-23.5 6.3-42 24.9-48.3 48.6C14.9 167 14.9 256.4 14.9 256.4s0 89.4 11.4 132.3c6.3 23.7 24.8 41.5 48.3 47.8C117.2 448 288 448 288 448s170.8 0 213.4-11.5c23.5-6.3 42-24.2 48.3-47.8 11.4-42.9 11.4-132.3 11.4-132.3s0-89.4-11.4-132.3M232.2 337.6V175.2l142.7 81.2z"/></symbol><symbol id="sprite-menu-close" viewBox="0 0 16.1 16.1"><title>menu-close</title><g data-name="Layer 2"><path d="M16.1 1.6 9.7 8.1l6.4 6.4-1.6 1.6-6.4-6.4-6.5 6.4L0 14.5l6.4-6.4L0 1.6 1.6 0l6.5 6.4L14.5 0Z" data-name="Layer 1" style="fill:#979797"/></g></symbol><symbol id="sprite-menu-open" viewBox="0 0 31.7 21.8"><title>menu-open</title><g data-name="Layer 2"><path d="M0 0h31.7v2.34H0zm0 9.8h31.7v2.34H0zm0 9.7h31.7v2.34H0z" data-name="Layer 1" style="fill:#979797"/></g></symbol></svg></div>	<div class="text-yellow-500" style="height: 0; width: 0; position: absolute; visibility: hidden;"><svg xmlns="http://www.w3.org/2000/svg">
+	<defs>
+		<linearGradient id="tasty-recipes-clip-0">
+			<stop stop-opacity="1" offset="0%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-10">
+			<stop stop-opacity="1" offset="10%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-20">
+			<stop stop-opacity="1" offset="20%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-30">
+			<stop stop-opacity="1" offset="30%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-40">
+			<stop stop-opacity="1" offset="40%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-50">
+			<stop stop-opacity="1" offset="50%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-60">
+			<stop stop-opacity="1" offset="60%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-70">
+			<stop stop-opacity="1" offset="70%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-80">
+			<stop stop-opacity="1" offset="80%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-90">
+			<stop stop-opacity="1" offset="90%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-100">
+			<stop stop-opacity="1" offset="100%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+
+		<linearGradient id="tasty-recipes-clip-mobile-0">
+			<stop stop-opacity="1" offset="0%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-10">
+			<stop stop-opacity="1" offset="10%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-20">
+			<stop stop-opacity="1" offset="20%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-30">
+			<stop stop-opacity="1" offset="30%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-40">
+			<stop stop-opacity="1" offset="40%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-50">
+			<stop stop-opacity="1" offset="50%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-60">
+			<stop stop-opacity="1" offset="60%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-70">
+			<stop stop-opacity="1" offset="70%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-80">
+			<stop stop-opacity="1" offset="80%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-90">
+			<stop stop-opacity="1" offset="90%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+		<linearGradient id="tasty-recipes-clip-mobile-100">
+			<stop stop-opacity="1" offset="100%" stop-color="currentColor"></stop>
+			<stop stop-opacity="0" offset="0%"></stop>
+		</linearGradient>
+	</defs>
+	<symbol id="wpt-star-full" viewBox="5 5 53 50">
+		<path d="m46.296296 51.906272-14.379945-9.431623-14.413639 9.380051 4.52636-16.590672-13.375018-10.80959 17.177389-.821975 6.147423-16.0607456 6.08985 16.0826626 17.174335.883504-13.413655 10.761608z" stroke="currentColor" stroke-width="2.5"/>
+	</symbol>
+</svg>
+</div>
+	<div class="top-nav-cta fixed l-0 r-0 w-full z-50 md:relative md:z-auto bg-purple-500 text-center py-2 px-4 flex items-center" style="height: 40px;">
+	<a data-formkit-toggle="3527a72463" href="https://pinchofyum.ck.page/3527a72463" class="top-nav-cta-link text-white mt-1 text-xs md:text-sm leading-none uppercase font-sans tracking-extra-widest mx-auto inline-block"><svg class="inline-block w-3 h-3 mr-1" viewBox="0 0 520 600" role="img" xmlns="http://www.w3.org/2000/svg">
+<path d="M462.3 31.6C407.5 -15.1 326 -6.7 275.7 45.2L256 65.5L236.3 45.2C186.1 -6.7 104.5 -15.1 49.7 31.6C-13.1 85.2 -16.4 181.4 39.8 239.5L233.3 439.3C245.8 452.2 266.1 452.2 278.6 439.3L472.1 239.5C528.4 181.4 525.1 85.2 462.3 31.6V31.6Z" fill="#EBB454"/>
+</svg> <span class="inline-block mr-1" style="color: #DDC5D8;">Our recipes, your inbox.</span> <span class="inline-block">Sign up</span></a>
+	<button class="top-nav-close w-3 h-3 text-white flex items-center" type="button" aria-label="close" style="color: #DDC5D8;"><svg width="12px" height="18px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M193.94 256L296.5 153.44l21.15-21.15c3.12-3.12 3.12-8.19 0-11.31l-22.63-22.63c-3.12-3.12-8.19-3.12-11.31 0L160 222.06 36.29 98.34c-3.12-3.12-8.19-3.12-11.31 0L2.34 120.97c-3.12 3.12-3.12 8.19 0 11.31L126.06 256 2.34 379.71c-3.12 3.12-3.12 8.19 0 11.31l22.63 22.63c3.12 3.12 8.19 3.12 11.31 0L160 289.94 262.56 392.5l21.15 21.15c3.12 3.12 8.19 3.12 11.31 0l22.63-22.63c3.12-3.12 3.12-8.19 0-11.31L193.94 256z"></path></svg></button>
+</div>
+
+<div class="top-nav-cta-shim block md:hidden" style="height:40px;"></div>
+
+<style>
+.slick-filmstrip-toolbar-showing .top-nav-cta {
+	visibility: hidden;
+}
+</style>
+		<header class="border-b relative">
+				<nav role="navigation" id="global-navigation" class="sm:flex sm:justify-between sm:items-center pb-4 pt-4 md:pt-8 px-4 lg:max-w-6xl lg:mx-auto">
+			<a href="https://pinchofyum.com"><svg class="w-48 sm:w-64" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 388.7 87">
+  <g id="Layer_2" data-name="Layer 2">
+    <g id="Layer_1-2" data-name="Layer 1">
+      <g>
+        <g>
+          <path d="M20,19.4A20.6,20.6,0,0,0,8.9,23.2V20.5a1,1,0,0,0-1.1-1.1H2.9l-.7.4a.8.8,0,0,0-.3.7v.5a1.1,1.1,0,0,0,.3.7.9.9,0,0,0,.7.3h.8a6.7,6.7,0,0,1,2.1.2H6V67H5.9a9.1,9.1,0,0,1-3.6.5H1a1.1,1.1,0,0,0-.7.3.8.8,0,0,0-.3.7v.5a1.1,1.1,0,0,0,.3.7,1.1,1.1,0,0,0,.7.3H15.1a1.1,1.1,0,0,0,.7-.3,1.1,1.1,0,0,0,.3-.8v-.4a1.1,1.1,0,0,0-.3-.8,1.1,1.1,0,0,0-.7-.3H12.7a8.1,8.1,0,0,1-3.6-.4H8.9V49.5A14.5,14.5,0,0,0,13,53.2a13.9,13.9,0,0,0,6.7,1.7,14.2,14.2,0,0,0,11-5.1,19.4,19.4,0,0,0,4.2-12.7,19.3,19.3,0,0,0-4.2-12.6A13.6,13.6,0,0,0,20,19.4Zm-.3,32.8a10.7,10.7,0,0,1-6.8-2.3,12.9,12.9,0,0,1-4-6.2V26.5c3.7-2.8,7.5-4.4,11.1-4.4a11,11,0,0,1,8.6,4.1A17.7,17.7,0,0,1,32,37.1,16.7,16.7,0,0,1,28.5,48,11,11,0,0,1,19.7,52.2Z" style="fill: #734060"/>
+          <path d="M46.5,12a2.4,2.4,0,0,0,1.7-.7,2.4,2.4,0,0,0,.7-1.6,2.2,2.2,0,0,0-.7-1.6,2.2,2.2,0,0,0-1.7-.7,2.4,2.4,0,0,0-2.3,2.3A2.4,2.4,0,0,0,46.5,12Z" style="fill: #734060"/>
+          <path d="M53,52.2H51.9a9.2,9.2,0,0,1-3.6-.4h-.2V20.4a1.1,1.1,0,0,0-.3-.7,1.1,1.1,0,0,0-.8-.3H42.1a.8.8,0,0,0-.7.3,1.1,1.1,0,0,0-.3.7V21a1.1,1.1,0,0,0,.3.8,1.5,1.5,0,0,0,.7.3h.8a4.5,4.5,0,0,1,2.1.2h.2V51.5h-.1a10.1,10.1,0,0,1-3.6.4H40.2a.9.9,0,0,0-.7.3,1.1,1.1,0,0,0-.3.7v.5a.8.8,0,0,0,.3.7.9.9,0,0,0,.7.3H53a1.1,1.1,0,0,0,.7-.3.9.9,0,0,0,.3-.7v-.5a.9.9,0,0,0-.3-.7A1.1,1.1,0,0,0,53,52.2Z" style="fill: #734060"/>
+          <path d="M98.3,52.1H97a8.1,8.1,0,0,1-3.6-.4.1.1,0,0,1-.1-.1h-.1V29.3a10,10,0,0,0-.8-4.3,8,8,0,0,0-4-4.3,15.2,15.2,0,0,0-6.8-1.4,14.2,14.2,0,0,0-9,3.6,21.4,21.4,0,0,0-4.8,5.9V20.4a1,1,0,0,0-1-1H61.9a1.1,1.1,0,0,0-.8.3,1.1,1.1,0,0,0-.3.7V21a.9.9,0,0,0,.3.7,1.1,1.1,0,0,0,.8.3h.8a6,6,0,0,1,2.1.3h.1s.1,0,.1.2V51.5h0c0,.1,0,.1-.2.2a11.7,11.7,0,0,1-3.5.4H60a1.1,1.1,0,0,0-.8.3,1.5,1.5,0,0,0-.3.7v.5a1,1,0,0,0,.4.7.8.8,0,0,0,.7.3H73.4a.9.9,0,0,0,.7-.3,1.1,1.1,0,0,0,.3-.7v-.5a.9.9,0,0,0-.3-.7,1.1,1.1,0,0,0-.7-.3H71.6a8,8,0,0,1-3.5-.5h-.2V38.9a18.7,18.7,0,0,1,4.3-11.7,15.2,15.2,0,0,1,4.4-3.7,10.8,10.8,0,0,1,5-1.4c3.1,0,5.3.7,6.6,1.9a6,6,0,0,1,1.6,2.2,9.8,9.8,0,0,1,.5,3.2V51.6h-.1a.1.1,0,0,1-.1.1,9.1,9.1,0,0,1-3.6.5H84.9a1.1,1.1,0,0,0-.8.3.9.9,0,0,0-.3.7v.5a1.1,1.1,0,0,0,.3.7,1.1,1.1,0,0,0,.8.3H98.3a1,1,0,0,0,1-1v-.5a1.1,1.1,0,0,0-.3-.8A1.1,1.1,0,0,0,98.3,52.1Z" style="fill: #734060"/>
+          <path d="M130.3,48.3a1,1,0,0,0-1.4-.1,17.5,17.5,0,0,1-11.1,3.9,13.9,13.9,0,0,1-10.4-4.2,15.2,15.2,0,0,1-4-10.8,15.8,15.8,0,0,1,3.8-10.9,13,13,0,0,1,9.9-4.2,15.7,15.7,0,0,1,7,1.6,7.2,7.2,0,0,1,2.1,1.6c.5.5,0,1.3,0,1.7a1.8,1.8,0,0,0,.6,1.6,2.2,2.2,0,0,0,1.8.3c.8-.2,1.1-.4,1.3-.8a2.4,2.4,0,0,0,.4-1.3,4.2,4.2,0,0,0-1.2-2.8,12,12,0,0,0-4.8-3.3,19.7,19.7,0,0,0-7.2-1.3,16.1,16.1,0,0,0-11.9,5.1,18,18,0,0,0-4.7,12.7,17.8,17.8,0,0,0,4.9,12.7,16.9,16.9,0,0,0,12.4,5,20.2,20.2,0,0,0,12.8-4.5,2,2,0,0,0,.4-.8,1.1,1.1,0,0,0-.3-.7Z" style="fill: #734060"/>
+          <path d="M173,52.1h-1.3a9.1,9.1,0,0,1-3.6-.5c-.1,0-.1,0-.1-.1h0V29.2a11.8,11.8,0,0,0-.7-4.3,9.2,9.2,0,0,0-4-4.3,15.9,15.9,0,0,0-6.8-1.4,14,14,0,0,0-9,3.6,19.8,19.8,0,0,0-4.8,5.9V5a1,1,0,0,0-.4-.7.9.9,0,0,0-.7-.3h-5.6a1,1,0,0,0-1,1v.5a.8.8,0,0,0,.3.7,1.1,1.1,0,0,0,.7.3h1.5a6,6,0,0,1,2.1.3h.2V51.4h-.1a10.1,10.1,0,0,1-3.6.4h-1.3a.9.9,0,0,0-.7.3,1.1,1.1,0,0,0-.3.7v.5a.8.8,0,0,0,.3.7.9.9,0,0,0,.7.3h13.4a1,1,0,0,0,1-1v-.5a1,1,0,0,0-1-1h-1.7a9.2,9.2,0,0,1-3.6-.4h-.2V38.9A18.6,18.6,0,0,1,147,27.2a17.4,17.4,0,0,1,4.4-3.8,10.2,10.2,0,0,1,5-1.4c3,0,5.1.7,6.5,1.9a6,6,0,0,1,1.6,2.2,7.6,7.6,0,0,1,.6,3.2V51.5h-.2a8.3,8.3,0,0,1-3.6.5h-1.7a.8.8,0,0,0-.7.3.9.9,0,0,0-.3.7v.5a1,1,0,0,0,1,1H173a.9.9,0,0,0,.7-.3,1.1,1.1,0,0,0,.3-.7v-.5a1,1,0,0,0-1-1Z" style="fill: #734060"/>
+          <path d="M283.1,19.3H270.4a1.1,1.1,0,0,0-.7.3.9.9,0,0,0-.3.7v.5a1,1,0,0,0,1,1h3.2a14.8,14.8,0,0,1,3.5.2h.3l-.2.5L265.6,50,255,24.5h0l-1-2.3-.8-1.3a4.9,4.9,0,0,0-1.8-1.4,5.3,5.3,0,0,0-2.3-.4,4.7,4.7,0,0,0-1.5.2,2.4,2.4,0,0,0-1,.5,1.2,1.2,0,0,0-.5.5,1.9,1.9,0,0,0-.2.8c0,.2.1.4.1.6a1.8,1.8,0,0,0,.7.8l.9.2h.5a2.7,2.7,0,0,1,1.2-.2h1.4a2.8,2.8,0,0,1,.6.8,21.7,21.7,0,0,1,1,2.1h0l11.2,27.1h0l.3.9a.4.4,0,0,1,.1.3c0,.1,0,.2.1.2l-.2.3h0c-1.7,4-3.4,7.3-5.4,9.5a11.8,11.8,0,0,1-3.1,2.5,8.2,8.2,0,0,1-3.5.8,8.5,8.5,0,0,1-4.7-1.2,4.5,4.5,0,0,1-1.2-1.2,2.9,2.9,0,0,1-.4-1.6c0-.3,1-1.1,1-2.2a2,2,0,0,0-.9-1.8,2.5,2.5,0,0,0-2.7.3,3.7,3.7,0,0,0-.6,1,5.6,5.6,0,0,0-.3,2.2,6.3,6.3,0,0,0,.7,3,7.3,7.3,0,0,0,3.6,3.1,13.1,13.1,0,0,0,5.5,1.1,10.8,10.8,0,0,0,4.7-1.1,15.6,15.6,0,0,0,5.5-5.1,42.8,42.8,0,0,0,4.3-8.3l13.4-31.8h0a1.9,1.9,0,0,1,1-1.3,4.8,4.8,0,0,1,2.1-.4h.3a1.1,1.1,0,0,0,.8-.3,1.1,1.1,0,0,0,.3-.7v-.5a.8.8,0,0,0-.3-.7A.8.8,0,0,0,283.1,19.3Z" style="fill: #734060"/>
+          <polygon points="244.4 60.5 244.4 60.5 244.4 60.5 244.4 60.5" style="fill: #734060"/>
+          <path d="M323.9,51.4l-2.9.5c0-.1-.1-.1-.1-.2a6.7,6.7,0,0,1-.6-1.2,10.6,10.6,0,0,1-.4-1.9h0l-.3-3.2V20.1a1,1,0,0,0-1-1h-5a1.1,1.1,0,0,0-.7.3,1.1,1.1,0,0,0-.3.8v.4a1.1,1.1,0,0,0,.3.8,1.1,1.1,0,0,0,.7.3h.8a8.2,8.2,0,0,1,2.2.2h.1a.3.3,0,0,1,.1.2V35a18.2,18.2,0,0,1-4.4,11.7,15.6,15.6,0,0,1-4.4,3.8,11.3,11.3,0,0,1-5,1.3c-3.1,0-5.3-.7-6.6-1.8a6.9,6.9,0,0,1-1.6-2.2,10.2,10.2,0,0,1-.5-3.2V20.2a1,1,0,0,0-1.1-1.1h-4.9a1,1,0,0,0-1,1.1v.5a1.1,1.1,0,0,0,.3.7.9.9,0,0,0,.7.3h.8a6.7,6.7,0,0,1,2.1.2h.2V44.7a11.2,11.2,0,0,0,.8,4.2,8,8,0,0,0,4,4.3,14,14,0,0,0,6.8,1.4,14.5,14.5,0,0,0,9-3.5,21.9,21.9,0,0,0,4.8-6v.4h0l.3,3.2h0a9.3,9.3,0,0,0,1,3.7,5.8,5.8,0,0,0,1.1,1.5,3.5,3.5,0,0,0,1.8.6h.2l3.1-.5c.3-.1.6-.2.7-.5a1,1,0,0,0,.2-.7v-.7A1.2,1.2,0,0,0,323.9,51.4Z" style="fill: #734060"/>
+          <path d="M388.4,52.1a1.1,1.1,0,0,0-.8-.3h-1.2a9.2,9.2,0,0,1-3.6-.4h-.2V28.9a10.7,10.7,0,0,0-.7-4.1,8.1,8.1,0,0,0-3.5-4.4,12.8,12.8,0,0,0-6.1-1.4,12.6,12.6,0,0,0-8.6,3.6,19,19,0,0,0-4,5.2,13.3,13.3,0,0,0-.6-3,8.7,8.7,0,0,0-3.6-4.4,13.2,13.2,0,0,0-6.2-1.4,12.8,12.8,0,0,0-8.6,3.6,22.2,22.2,0,0,0-3.9,5.1V20.1a1,1,0,0,0-1-1h-5a1,1,0,0,0-1,1v.5a.8.8,0,0,0,.3.7,1.1,1.1,0,0,0,.7.3h.8a6.8,6.8,0,0,1,2.2.3h.1V51.2h-.2a9.2,9.2,0,0,1-3.6.4H329a1.1,1.1,0,0,0-.8.3,1.1,1.1,0,0,0-.3.7v.5a.9.9,0,0,0,.3.7,1.1,1.1,0,0,0,.8.3h13.4a1.1,1.1,0,0,0,.7-.3.9.9,0,0,0,.3-.7v-.5a.9.9,0,0,0-.3-.7,1.1,1.1,0,0,0-.8-.3h-1.7a10.1,10.1,0,0,1-3.6-.4h-.1V38.7a20.3,20.3,0,0,1,3.8-11.8,11.7,11.7,0,0,1,4-3.7,9.2,9.2,0,0,1,4.7-1.4,11.1,11.1,0,0,1,3.4.5,5.7,5.7,0,0,1,3.1,2.3,8.3,8.3,0,0,1,1.1,4.5V51.3h0a.1.1,0,0,1-.1.1,9.1,9.1,0,0,1-3.6.5h-1a1.1,1.1,0,0,0-.7.3.9.9,0,0,0-.3.7v.5a.9.9,0,0,0,.3.7,1.1,1.1,0,0,0,.7.3h12.3a.8.8,0,0,0,.7-.3,1.3,1.3,0,0,0,.4-.7v-.5a.8.8,0,0,0-.4-.7.8.8,0,0,0-.7-.3h-.9a8.3,8.3,0,0,1-3.6-.5h-.2V38.6a20.4,20.4,0,0,1,3.7-11.8,13.5,13.5,0,0,1,4-3.6,9.2,9.2,0,0,1,4.8-1.4,11.6,11.6,0,0,1,3.4.5,5.8,5.8,0,0,1,3,2.3,9.2,9.2,0,0,1,1,4.4V51.3h0a.1.1,0,0,1-.1.1,10.1,10.1,0,0,1-3.6.4h-1l-.7.3a1.1,1.1,0,0,0-.3.8v.5a1,1,0,0,0,1,1h12.6a1,1,0,0,0,1.1-1.1v-.4A1.1,1.1,0,0,0,388.4,52.1Z" style="fill: #734060"/>
+        </g>
+        <path d="M236.4,41.5h-.6a1.6,1.6,0,0,0-1.2.6,20.2,20.2,0,0,1-2.6,3.2,16.1,16.1,0,0,1-3,2.1,16.3,16.3,0,0,1-3.7,1.3l-2.3.2h-3.3l-2.9-.6-.4-.2c-.1-.1-.3-.2-.3-.4a.5.5,0,0,1,0-.6h0c.1-.6.1-1.2.2-1.8h0c.1-.5.1-1,.2-1.6a1.5,1.5,0,0,1,.3-.7h0l2.1-2.3,2.2-2.7h0c1.2-1.7,2.4-3.4,3.5-5.2a46.5,46.5,0,0,0,3.2-6.3,41.3,41.3,0,0,0,2.4-7,17.2,17.2,0,0,0,.8-3.8,7.6,7.6,0,0,0,.3-2.1c.1-1,.3-1.9.3-2.8v-1a19.8,19.8,0,0,0-.3-3.5,8.6,8.6,0,0,0-1.9-4.7A4.2,4.2,0,0,0,227.9.3a3.3,3.3,0,0,0-1.5-.3h-.6a4.5,4.5,0,0,0-2.5,1.2,10.8,10.8,0,0,0-3,4.6,50.8,50.8,0,0,0-1.7,5.1c-.8,3-1.3,6-1.9,9.1l-.6,3.8c-.1,1.3-.3,2.6-.4,3.9h0c-.1.4-.1.9-.2,1.4a9.9,9.9,0,0,0-.2,1.7h0a12.3,12.3,0,0,0-.2,1.9h0c-.1.5-.1,1.1-.2,1.6h0a12.3,12.3,0,0,0-.2,2h0c-.1.6-.1,1.2-.2,1.9h0l-.3,2.5h0a3.2,3.2,0,0,1-.6,1.8h0a10.5,10.5,0,0,1-4.6,3.4,11.4,11.4,0,0,1-2.5.6h-4.3l.5-.8,1-1.7a15.7,15.7,0,0,0,1.5-2.9,9.4,9.4,0,0,0,1-2.8h0l.6-2.7a16.3,16.3,0,0,0,.3-3.1,5.3,5.3,0,0,0,.1-1.3c0-.6-.1-1.2-.1-1.8h0a14.2,14.2,0,0,0-.4-2h0a9.3,9.3,0,0,0-2.8-4.9,7.4,7.4,0,0,0-2.2-1.4,10.5,10.5,0,0,0-2.4-.6h-3.1a11.4,11.4,0,0,0-4.3,1.7,18.3,18.3,0,0,0-4.6,4.6,37.5,37.5,0,0,0-2.4,4.4c-.3,1-.7,1.9-.9,2.9s-.3,1.8-.5,2.8h0a26.4,26.4,0,0,0-.2,2.8c0,.2-.1.3-.1.5a21.1,21.1,0,0,0,.2,2.5,16.8,16.8,0,0,0,.9,3.2,10,10,0,0,0,2,2.9,7.1,7.1,0,0,0,2.7,1.8,11.7,11.7,0,0,0,3.8.7h.2l1.6-.2a10.4,10.4,0,0,0,4.4-2,2,2,0,0,1,1.3-.4h.3a2.3,2.3,0,0,1,1.1.2h4.2a17.5,17.5,0,0,0,6.6-2.2l.4-.3.3.5a1.7,1.7,0,0,1,.1.7,5.4,5.4,0,0,1-.1.8l-.3,2.6c-.1,1-.3,1.9-.4,2.9h0a6.9,6.9,0,0,0-.2,1.3h0c-.1.9-.3,1.7-.4,2.6h0l-.3,2.5-.6,3.7h0c-.1.4-.1.8-.2,1.3h0c-.1.8-.3,1.6-.4,2.5h0l-.3,2.4c-.1.9-.3,1.7-.4,2.5s-.3,2-.4,3a5.2,5.2,0,0,0-.2,1.1h0v2.3h0a7.6,7.6,0,0,0,.3,2.1h0a8.6,8.6,0,0,0,1.3,2.9,5.5,5.5,0,0,0,2.4,1.8,7.6,7.6,0,0,0,2.6.6h.1l1.2-.2a8,8,0,0,0,2.5-1.1,10.9,10.9,0,0,0,2.4-2.4,11.4,11.4,0,0,0,1.5-3.4,26.8,26.8,0,0,0,.7-2.7,26,26,0,0,0,.3-2.6,21.8,21.8,0,0,0,.1-2.5v-.8l-.3-3.9h0a12.9,12.9,0,0,0-.4-1.9c-.4-1.6-.8-3.2-1.3-4.7a41.6,41.6,0,0,0-1.6-4l-1.1-2.2h0a23.9,23.9,0,0,0-1.2-2.2l-.2-.5-.2-.6h1.2l.9.2h3.2a11.8,11.8,0,0,0,3.1-.5,15.4,15.4,0,0,0,7.6-4.4,16.8,16.8,0,0,0,2.5-2.9l.3-.9h0v-.2A1.1,1.1,0,0,0,236.4,41.5Zm-19.2-5.1c0-.4.1-.8.1-1.1l.3-1.9h0c.1-.5.1-.9.2-1.4h0c0-.6.1-1.2.1-1.8h0l.3-1.7h0c.1-.4.1-.9.2-1.4h0c.2-1.4.3-2.8.5-4.2s.5-3.3.8-5h0c.5-2.2.9-4.5,1.5-6.7s.9-2.9,1.5-4.3a10.1,10.1,0,0,1,2.2-3.7,1.7,1.7,0,0,1,1.2-.5h.2a2.1,2.1,0,0,1,1.1.4l.5.7h0a7.3,7.3,0,0,1,.9,2.3,21.9,21.9,0,0,1,.3,3.6v1l-.3,2.6h0a28.7,28.7,0,0,1-.5,3.1,33.8,33.8,0,0,1-.8,3.4,38.2,38.2,0,0,1-1.8,5.1,49.7,49.7,0,0,1-2.5,5.2c-.9,1.6-1.9,3-2.8,4.5s-1.5,1.9-2.3,2.9l-.8,1.1V36.5ZM195.7,48.1c-.1,0-.1.1-.2.2l-.3.2h0a5.8,5.8,0,0,1-1.8.4h-1.3a7,7,0,0,1-3-.9,5,5,0,0,1-2.1-2.4,10.3,10.3,0,0,1-1.1-3.9c0-.3-.1-.7-.1-1.1v-.2h0c.1-1,.1-2,.3-3h0v-.4a1.6,1.6,0,0,1,.3-.8l.5-.7.3.9a4.9,4.9,0,0,1,.4,1.1h0a15.3,15.3,0,0,0,1.8,3.9,13.3,13.3,0,0,0,2.3,3,10.4,10.4,0,0,0,3.2,2.3h0l.7.5.7.3Zm4.5-3.5-.9,1-.3.3h-.3a12.5,12.5,0,0,1-5.8-3.8,14.8,14.8,0,0,1-3.3-6.9,13.3,13.3,0,0,1-.3-2.8v-.4h0a9.9,9.9,0,0,1,2-5.7,8.3,8.3,0,0,1,2.1-1.7,9.5,9.5,0,0,1,3.5-1.4h1.3a7,7,0,0,1,3.6,1.2,5,5,0,0,1,1.8,2.3h0a9,9,0,0,1,.9,3.3,12.1,12.1,0,0,1,.1,1.9v.8c0,.8-.2,1.5-.2,2.2h0a20,20,0,0,1-.5,2.6,18.5,18.5,0,0,1-1.8,4.4A17.3,17.3,0,0,1,200.2,44.6Zm18.3,13.2a46.5,46.5,0,0,1,2,5.2c.4,1.3.7,2.6,1,4a25.9,25.9,0,0,1,.4,4.8v2.3a14,14,0,0,1-.7,4,11.7,11.7,0,0,1-.6,2,7.9,7.9,0,0,1-1.8,2.9,4.7,4.7,0,0,1-3.2,1.4h-.2a3.6,3.6,0,0,1-2.5-1.3,5.6,5.6,0,0,1-1.3-3.5h0V78.3c.1-.6.1-1.2.2-1.9s.3-1.8.4-2.7h0c.2-.9.3-1.7.4-2.5s.2-1.6.4-2.4h0a25.1,25.1,0,0,1,.4-2.7h0l.3-2.2c.1-1,.3-1.9.4-2.8l.3-2.6h0a17,17,0,0,1,.4-2.2h0a11.1,11.1,0,0,1,.2-1.7h0c.1-.3.1-.6.2-1.1l.2-1.4.7,1.2.9,1.5h0C217.5,55.8,218.1,56.8,218.5,57.8Z" style="fill: #979797;fill-rule: evenodd"/>
+      </g>
+    </g>
+  </g>
+<title>Pinch of Yum logo</title></svg>
+</a>
+			<button id="burgerBtn" aria-label="navigation button" aria-expanded="false" aria-controls="menu"></button>
+			<ul class="menu sm:flex sm:mt-2 shadow-md md:shadow-none">
+								<li><a class="mx-4 sm:-mb-7 pb-7 block font-sans font-bold uppercase tracking-wider text-black no-underline md:border-b-3 md:border-transparent" href="https://pinchofyum.com">Home</a></li>
+								<li><a class="mx-4 sm:-mb-7 pb-7 block font-sans font-bold uppercase tracking-wider text-black no-underline md:border-b-3 md:border-transparent" href="https://pinchofyum.com/about">About</a></li>
+								<li><a class="mx-4 sm:-mb-7 pb-7 block font-sans font-bold uppercase tracking-wider text-black no-underline md:border-b-3 md:border-transparent" href="https://pinchofyum.com/recipes">Recipes</a></li>
+								<li><a class="mx-4 sm:-mb-7 pb-7 block font-sans font-bold uppercase tracking-wider text-black no-underline md:border-b-3 md:border-transparent" href="https://pinchofyum.com/start-here">Start Here</a></li>
+				<li><a class="search-button" href="https://pinchofyum.com/?s="><svg class="w-5 h-5 text-black ml-4" role="presentation" aria-hidden="true"><use xlink:href="#sprite-icon-search"></use></svg></a></li>
+			</ul>
+		</nav>
+	</header>
+	<script>
+		(function(){
+			// Mobile Navigation script
+			var burgerBtn = document.getElementById('burgerBtn');
+			var globalNavigation = document.getElementById('global-navigation');
+			var menu = document.querySelector('.menu');
+			// when the mobile burger button is clicked, toggle a class of navigation to the main section
+			burgerBtn.addEventListener('click', function() {
+				globalNavigation.classList.toggle('navigation');
+			// when the mobile burger button is clicked, replaces 'aria-expanded=false' to true
+				if (menu.classList.contains('is-active')) {
+					this.setAttribute('aria-expanded', 'false');
+					menu.classList.remove('is-active');
+				} else {
+					menu.classList.add('is-active');
+					this.setAttribute('aria-expanded', 'true');
+				}
+			})
+		})();
+	</script>
+
+<main>
+	<div class="mb-2 overflow-x-scroll lg:overflow-x-auto poy-breadcrumb-container bg-gray-100">
+		<div class="md:max-w-6xl lg:mx-auto pt-2 pb-2 md:pb-2"><nav class="poy-breadcrumb gray-post-breadcrumb"><span><span><a href="https://pinchofyum.com/recipes">Recipes</a></span>  <span class="breadcrumb_last" aria-current="page"><a href="https://pinchofyum.com/recipes/fish">Fish and Seafood</a></span></span></nav></div>
+	</div>
+	<div class="adthrive_header_ad"></div>
+	<div class="md:grid grid-cols-12 md:max-w-6xl px-4 mx-auto">
+					<article class="col-span-7 post-23546 post type-post status-publish format-standard has-post-thumbnail hentry category-all category-avocado category-dinner category-fish category-lime category-lunch category-main-dishes category-popular category-quick-and-easy category-sugar-free category-summer category-taco">
+									<header class="mb-4 entry-header">
+						<h1 class="entry-title mb-2">Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw</h1>
+						<a href="#respond">
+							<div class="flex items-center flex-wrap recipe-rating">
+	<div class="space-x-1 flex mr-2"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="4.8"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="4.8"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="4.8"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="4.8"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="80" data-rating="4.8"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></div>
+	<div class="text-xxs text-gray-700 tracking-wider md:tracking-extra-widest uppercase font-arvo">
+		<span>312 reviews</span> / <span>4.8 average</span>
+	</div>
+</div>
+						</a>
+					</header>
+								<div class="mb-6 entry-content italic"><p>THE BEST shrimp tacos loaded with avocado, spicy shrimp, and a homemade creamy lime slaw? HELLO YUMMY!</p>
+</div>				<div class="entry-content">
+					<div class="tasty-recipes-quick-links"><a class="tasty-recipes-jump-link tasty-recipes-scrollto" href="#tasty-recipes-40894-jump-target">Jump to Recipe</a></div>
+
+
+<p class="wp-block-paragraph">It&#8217;s almost hard to talk about these tacos, that&#8217;s how much I love them.</p>
+
+
+
+<figure class="wp-block-image size-full"><style style="display: none !important;">.tasty-pins-banner-container{display:block;margin-bottom:20px;position:relative;width:-moz-fit-content;width:fit-content}.tasty-pins-banner-container a{cursor:pointer;display:flex;font-size:14px;font-weight:700;letter-spacing:1px;line-height:1.8em;text-transform:uppercase}.tasty-pins-banner-container a:hover{opacity:1}.tasty-pins-banner-container .tasty-pins-banner{align-items:center;bottom:0;cursor:pointer;display:flex;justify-content:center;left:0;padding-bottom:1em;padding-top:1em;position:absolute;right:0}.tasty-pins-banner-container .tasty-pins-banner svg{margin-right:4px;width:32px}.tasty-pins-banner-container .tasty-pins-banner span{margin-top:4px}.tasty-pins-banner-container a.tasty-pins-banner{text-decoration:none}.tasty-pins-banner-container a.tasty-pins-banner:hover{opacity:.8}.tasty-pins-banner-container a.tasty-pins-banner-image-link{flex-direction:column}.tasty-pins-banner-container a img{margin-bottom:0}.entry-content .wp-block-image .tasty-pins-banner-container img{margin-bottom:0;padding-bottom:0}#et-boc .et-l div .et_pb_image_wrap .tasty-pins-banner-container .tasty-pins-banner{padding-bottom:1em!important;padding-top:1em;text-decoration:none}#et-boc .et-l div .et_pb_image_wrap .tasty-pins-banner-container a.tasty-pins-banner{cursor:pointer;display:flex;font-size:14px;font-weight:700;line-height:1.8em;text-transform:uppercase}#et-boc .et-l div .et_pb_image_wrap .tasty-pins-banner-container a.tasty-pins-banner span{letter-spacing:2px;margin-top:4px}.et-db #et-boc .et-l .et_pb_module .tasty-pins-banner-container a:not(.wc-forward){padding-bottom:0}
+</style>
+
+<div class="tasty-pins-banner-container"><a class="tasty-pins-banner-image-link" data-pin-custom="true" href="https://www.pinterest.com/pin/create/button/?url=https%3A%2F%2Fpinchofyum.com%2Fspicy-shrimp-tacos-with-garlic-cilantro-lime-slaw&#038;media=https%3A%2F%2Fpinchofyum.com%2Ftachyon%2FShrimp-Tacos-with-Slaw.jpg"><img fetchpriority="high" width="1200" height="1800" decoding="async" data-pin-url="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?tp_image_id=54264" data-pin-description="The Best Shrimp Tacos with Garlic Cilantro Lime Slaw - ready in about 30 minutes and loaded with flavor and texture. SO YUM! #tacos #tacotuesday #shrimp" data-pin-title="Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw" loading="eager" src="https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw.jpg" alt="Spicy shrimp tacos with sauce." class="wp-image-54264" srcset="https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw.jpg?resize=1200%2C1800&amp;zoom=1 1200w, https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw.jpg?resize=1200%2C1800&amp;zoom=0.5 600w, https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw.jpg?resize=1200%2C1800&amp;zoom=0.25 300w" sizes="(min-width: 1220px) 653px, (min-width: 780px) calc(51.67vw + 33px), calc(100vw - 32px)" /></a><a data-pin-custom="true" href="https://www.pinterest.com/pin/create/button/?url=https%3A%2F%2Fpinchofyum.com%2Fspicy-shrimp-tacos-with-garlic-cilantro-lime-slaw&#038;media=https%3A%2F%2Fpinchofyum.com%2Ftachyon%2FShrimp-Tacos-with-Slaw.jpg" class="tasty-pins-banner" style="background-color: rgba(255,255,255,0.68); color: #734060; "><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 42 27.3"><g><path d="M8.9,17.8c-.4,1.2-.7,2.4-1,3.5A13.8,13.8,0,0,1,5,27.1l-.3.2L4.5,27a17.3,17.3,0,0,1,.3-6.8C5.5,17.8,6,15.4,6.6,13a1.3,1.3,0,0,0-.1-.6,5.9,5.9,0,0,1,.2-4.7A2.8,2.8,0,0,1,9,6.1a2.1,2.1,0,0,1,2.2,1.7A5,5,0,0,1,11,9.9c-.3,1.3-.7,2.5-1.1,3.8a2.5,2.5,0,0,0,.7,2.8,3,3,0,0,0,3,.3A4.3,4.3,0,0,0,15.8,15a10,10,0,0,0,1.5-4.7,11.3,11.3,0,0,0,0-2.6,5.4,5.4,0,0,0-3.6-4.6A8.3,8.3,0,0,0,5.8,4.3a7.1,7.1,0,0,0-2.6,7.3A4.8,4.8,0,0,0,4,13.2a1.2,1.2,0,0,1,.3,1.1L4,15.4c-.2.4-.4.6-.9.4A4.8,4.8,0,0,1,1,13.9,8.2,8.2,0,0,1,0,9.3,10,10,0,0,1,8,.4a11.7,11.7,0,0,1,7.8.6,8.7,8.7,0,0,1,5.3,6.8,11.3,11.3,0,0,1-.9,6.5,8.8,8.8,0,0,1-2.8,3.8,7,7,0,0,1-5.7,1.5A3.8,3.8,0,0,1,8.9,17.8Z" fill="currentColor" /><path d="M27.1,22.5l-1.4,1a4.1,4.1,0,0,1-3.2.7,2.3,2.3,0,0,1-2.1-2.5,11.3,11.3,0,0,1,.6-3.6c.5-2.2,1.1-4.5,1.7-6.7.2-.6.2-.7.9-.7h1.9c.6,0,.7.1.6.7l-1.8,6.8L24,20.1a.8.8,0,0,0,0,.7.9.9,0,0,0,1.1.8,2.2,2.2,0,0,0,1.4-.6,6.8,6.8,0,0,0,1.8-3.2c.5-2.1,1.1-4.2,1.6-6.3s.3-.8,1-.8h2c.4,0,.5.2.4.6s-.1.5-.1.8l.2-.3a5.4,5.4,0,0,1,4.2-1.4,3,3,0,0,1,2.7,3,7.8,7.8,0,0,1-.4,2.2c-.3,1.4-.6,2.8-1,4.2v.5a1.2,1.2,0,0,0,1.9,1.1l.2-.2,1,1.3-.9.8a4.2,4.2,0,0,1-3.4.9,2.4,2.4,0,0,1-2.3-2.7,18.8,18.8,0,0,1,.5-3.3c.2-1.1.5-2.1.8-3.2v-.8a1.2,1.2,0,0,0-1.1-1.1A3,3,0,0,0,33,14.3a7.1,7.1,0,0,0-1.1,2.5c-.5,2.2-1.1,4.4-1.6,6.6-.2.5-.3.6-.8.6H27.4c-.5,0-.6-.2-.5-.7A3.1,3.1,0,0,1,27.1,22.5Z" fill="currentColor" /><path d="M25.7,5.4a1.7,1.7,0,0,1,1.7,2,2.8,2.8,0,0,1-2.2,2.2,1.7,1.7,0,0,1-2-2.1A2.5,2.5,0,0,1,25.7,5.4Z" fill="currentColor" /></g></svg> <span>this recipe</span></a></div>
+
+<script style="display: none !important;">(()=>{"use strict";document.querySelectorAll(".tasty-pins-banner-container a").forEach(function(t){t.addEventListener("click",function(e){if("object"==typeof window.PinUtils)return;e.preventDefault();const n=t.getAttribute("href"),o=document.createEvent("Event");o.initEvent("tasty-pinit-button-click",!0,!0),document.dispatchEvent(o),window.open(n,"tastybanner"+(new Date).getTime(),"status=no,resizable=yes,scrollbars=yes,personalbar=no,directories=no,location=no,toolbar=no,menubar=no,width=800,height=900,left=0,top=0")})})})();</script></figure>
+
+
+<div class="featured-comment disable-link-style">
+	<div class="featured-comment-content">
+		<h5>Featured comment</h5>
+		<div class="comment-text w-full" itemprop="text"><p>These tacos are so fresh and delicious with just the right amount of heat to them. Great flavors and textures and super healthy too!</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+	</div>
+	<div class="featured-comment-meta">
+		<p><img decoding="async" data-pin-description="The Best Shrimp Tacos with Garlic Cilantro Lime Slaw - ready in about 30 minutes and loaded with flavor and texture. SO YUM! #tacos #tacotuesday #shrimp" data-pin-title="Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw" data-pin-nopin="nopin" loading="eager" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/6df0680ed7b77fb9674814e2ccb73d859c7be88bc17931ceeb21a476afffdb9d?s=24&amp;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey.jpg&amp;r=g" class="square-image avatar avatar-24 photo rounded-full w-4 h-4 mr-2" height="24" width="24" /><span class="fn">Kayla Geary</span></p>
+		<p class="inline-flex font-arvo uppercase tracking-widest text-xxs">
+			<a class="text-gray-500 flex" href="#comments">
+				<svg class="w-4 h-4 mr-2" role="presentation" aria-hidden="true"><title>comment icon</title><use xlink:href="#sprite-icon-comment"></use></svg>		791 more comments			</a>
+		</p>
+	</div>
+</div>
+
+
+
+<p class="wp-block-paragraph">What we have going on here is delicious spice-loaded shrimp tucked in between smashed avocado and a cabbage slaw that is&nbsp;heavy&nbsp;with a&nbsp;homemade creamy lime sauce. Question: topped with crumbly, salty Cotija cheese, and wrapped in a corn tortilla with a wedge of lime squeezed over the top? Answer: Yes.</p>
+
+
+
+<p class="wp-block-paragraph">More cilantro. More lime. More avocado and spicy shrimp. </p>
+
+
+
+<p class="wp-block-paragraph">The world just seems so right.</p>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity" />
+
+
+
+<h2 class="wp-block-heading" id="h-in-this-post-everything-you-need-for-spicy-shrimp-tacos">In This Post: Everything You Need For Spicy Shrimp Tacos</h2>
+
+
+
+<ul class="wp-block-list">
+<li><a href="#watch">VIDEO for How to Make Spicy Shrimp Tacos</a></li>
+
+
+
+<li><a href="#ingredients">Ingredients You&#8217;ll Need</a></li>
+
+
+
+<li><a href="#sauce">Best Shrimp Taco Sauce</a></li>
+
+
+
+<li><a href="#cook-shrimp">How to Cook Shrimp for Tacos</a></li>
+
+
+
+<li><a href="#serve">What to Serve with These Spicy Shrimp Tacos</a></li>
+
+
+
+<li><a href="#faq">Spicy Shrimp Tacos: Frequently Asked Questions</a></li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity" />
+
+
+
+<h2 class="wp-block-heading" id="watch">Video To Make This Recipe</h2>
+
+
+
+
+<div class="adthrive-video-player in-post" itemscope itemtype="https://schema.org/VideoObject" data-video-id="1uLiMsIQ" data-player-type="default" orientation="" override-embed="default">
+			<meta itemprop="uploadDate" content="2021-05-20T15:15:23.000Z" />
+		<meta itemprop="name" content="Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw" />
+		<meta itemprop="description" content="The BEST Shrimp Tacos with Garlic Cilantro Lime Slaw – ready in about 30 minutes and loaded with flavor and texture. SO YUM!" />
+		<meta itemprop="thumbnailUrl" content="https://content.jwplatform.com/thumbs/1uLiMsIQ-720.jpg" />
+		<meta itemprop="contentUrl" content="https://content.jwplatform.com/videos/1uLiMsIQ.mp4" />
+	</div>
+
+
+
+
+<h2 class="wp-block-heading" id="ingredients">Ingredients You&#8217;ll Need For These Tacos</h2>
+
+
+
+<p class="wp-block-paragraph">What I love about these tacos is that your grocery list will be pretty short and sweet!</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Shrimp:</strong> I recommend getting large shrimp for these tacos &#8211; they&#8217;re hefty enough to fill a tortilla and look amazing, but small enough to eat. I also recommend getting frozen shrimp that is peeled and deveined, with tails off.</li>
+
+
+
+<li><strong>Spices:</strong> You&#8217;ll season the shrimp with a really yummy spice mix &#8211; chili powder, cumin, onion powder, garlic powder, and cayenne. Kind of a basic taco seasoning mix!</li>
+
+
+
+<li><strong>Cabbage: </strong>Shred your own cabbage (green or purple works!) or us a bag of pre-shredded to keep it even easier.</li>
+
+
+
+<li><strong>Garlic Cilantro Lime Sauce:</strong> More on that below!</li>
+
+
+
+<li><strong>Tortillas:</strong> You can use corn or flour, but I actually prefer flour tortillas when it comes to fish / shrimp tacos!</li>
+
+
+
+<li><strong>Toppings: </strong>Avocado, lime, cotija, cilantro, anything!</li>
+</ul>
+
+
+
+<h2 class="wp-block-heading" id="sauce">The Best Shrimp Taco Sauce</h2>
+
+
+
+<p class="wp-block-paragraph">So, let’s talk more about that garlic cilantro lime sauce for these shrimp tacos, because honestly, it might just be the best part.</p>
+
+
+
+<p class="wp-block-paragraph">All you need is:</p>
+
+
+
+<ul class="wp-block-list">
+<li><strong>Sour cream</strong> &#8211;&nbsp; For a healthier choice, you could use greek yogurt.</li>
+
+
+
+<li><strong>Fresh lime juice</strong> &#8211; Adds some zing that makes the flavors pop!</li>
+
+
+
+<li><strong>Garlic &#8211; </strong>A little punchy, a lotta flavor.</li>
+
+
+
+<li><strong>Herbs</strong> &#8211; Cilantro and green onions.</li>
+
+
+
+<li><strong>Olive oil</strong>&nbsp; &#8211; Adds a smooth texture that brings it all together!<br></li>
+</ul>
+
+
+
+<p class="wp-block-paragraph">Blitz it all up together and you’re in business.</p>
+
+
+
+<p class="wp-block-paragraph">We’re gonna toss it with some shredded cabbage (see above) and ALSO give these tacos a good shower on top. Because there is no such thing as too much sauce. Especially when it comes to tacos.</p>
+
+
+<div class="wp-block-image">
+<figure class="aligncenter size-full"><img loading="lazy" width="1200" height="1800" decoding="async" data-pin-url="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?tp_image_id=23556" data-pin-description="The Best Shrimp Tacos with Garlic Cilantro Lime Slaw - ready in about 30 minutes and loaded with flavor and texture. SO YUM! #tacos #tacotuesday #shrimp" data-pin-title="Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw" src="https://pinchofyum.com/tachyon/Shrimp-Tacos.jpg" alt="Garlic cilantro lime slaw in a bowl with forks. " class="wp-image-23556" srcset="https://pinchofyum.com/tachyon/Shrimp-Tacos.jpg?resize=1200%2C1800&amp;zoom=1 1200w, https://pinchofyum.com/tachyon/Shrimp-Tacos.jpg?resize=1200%2C1800&amp;zoom=0.5 600w, https://pinchofyum.com/tachyon/Shrimp-Tacos.jpg?resize=1200%2C1800&amp;zoom=0.25 300w" sizes="(min-width: 1220px) 653px, (min-width: 780px) calc(51.67vw + 33px), calc(100vw - 32px)" /></figure>
+</div>
+
+
+<h2 class="wp-block-heading" id="cook-shrimp">How To Cook Shrimp For Tacos</h2>
+
+
+
+<h3 class="wp-block-heading" id="h-how-to-prepare-the-shrimp">How to Prepare the Shrimp</h3>
+
+
+
+<p class="wp-block-paragraph">It might give you the scaries but I&#8217;d recommend getting tail-on shrimp (fresh or frozen) and peel and devein them yourself. Don&#8217;t worry &#8211; it&#8217;s <a aria-label="easier than you think (opens in a new tab)" rel="noreferrer noopener" href="https://www.wikihow.com/Peel-and-Devein-Shrimp" target="_blank">easier than you think</a>.</p>
+
+
+
+<h3 class="wp-block-heading" id="h-ways-to-cook-the-shrimp">Ways to Cook the Shrimp</h3>
+
+
+
+<p class="wp-block-paragraph">These are made in a skillet, but if the sun is shining and the beer is cold and the grill is hot, then you do you and grill those shrimp! Might be best to get them on <a href="https://geni.us/jw4d894" target="_blank" rel="noreferrer noopener sponsored nofollow">some skewers</a> <em>(affiliate link)</em> for a much less frustrating grilling experience.</p>
+
+
+
+<h3 class="wp-block-heading" id="h-beer-battered-shrimp-tacos-yum">Beer-Battered Shrimp Tacos (YUM)</h3>
+
+
+
+<p class="wp-block-paragraph">For those with extra time on their hands and a heart set on fried shrimp: the&nbsp;<a href="https://pinchofyum.com/crispy-fish-tacos-jalapeno-sauce" target="_blank" rel="noreferrer noopener">beer batter instructions in this recipe&nbsp;</a>work for shrimp, too!&nbsp;</p>
+
+
+
+<figure class="wp-block-image size-full"><img loading="lazy" width="1200" height="1800" decoding="async" data-pin-url="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?tp_image_id=54262" data-pin-description="The Best Shrimp Tacos with Garlic Cilantro Lime Slaw - ready in about 30 minutes and loaded with flavor and texture. SO YUM! #tacos #tacotuesday #shrimp" data-pin-title="Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw" src="https://pinchofyum.com/tachyon/Easy-Shrimp-Tacos.jpg" alt="Shrimp tacos with sauce." class="wp-image-54262" srcset="https://pinchofyum.com/tachyon/Easy-Shrimp-Tacos.jpg?resize=1200%2C1800&amp;zoom=1 1200w, https://pinchofyum.com/tachyon/Easy-Shrimp-Tacos.jpg?resize=1200%2C1800&amp;zoom=0.5 600w, https://pinchofyum.com/tachyon/Easy-Shrimp-Tacos.jpg?resize=1200%2C1800&amp;zoom=0.25 300w" sizes="(min-width: 1220px) 653px, (min-width: 780px) calc(51.67vw + 33px), calc(100vw - 32px)" /></figure>
+
+
+
+<h2 class="wp-block-heading" id="serve">What To Serve with These Spicy Shrimp Tacos</h2>
+
+
+
+<p class="wp-block-paragraph">Obviously you&#8217;ll be pocketing those delicious shrimp inside corn or flour tortillas, sprinkling on some garlic cilantro lime slaw, and dousing it in even more sauce and herbs, but you can also make this an entire taco feast!</p>
+
+
+
+<p class="wp-block-paragraph">Here are some of our favorite recipes to make alongside these delicious little pockets of goodness.</p>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://pinchofyum.com/elote-queso">Elote Queso</a></li>
+
+
+
+<li><a href="https://pinchofyum.com/pitcher-style-margaritas-for-a-crowd">Pitcher Style Margaritas for a Crowd</a></li>
+
+
+
+<li><a href="https://pinchofyum.com/avocado-dip">2-Minute Creamy Avocado Dip</a></li>
+
+
+
+<li><a href="https://pinchofyum.com/corn-avocado-and-quinoa-salad-with-marinated-tomatoes">Corn, Avocado, and Quinoa Salad with Marinated Tomatoes</a></li>
+
+
+
+<li><a href="https://www.yellowblissroad.com/authentic-mexican-rice/" target="_blank" rel="noreferrer noopener">Classic Mexican Rice</a></li>
+</ul>
+
+
+
+<p class="wp-block-paragraph">These shrimp tacos are fast, easy, and&nbsp;give me something to look&nbsp;forward to at the end of the day. </p>
+
+
+
+<p class="wp-block-paragraph">Cheers to many warm-weather nights with tons and tons of shrimp tacos in your future!</p>
+
+
+
+<h2 class="faq-heading" id="faq">Spicy Shrimp Tacos: Frequently Asked Questions</h2>
+
+
+
+<div class="schema-faq wp-block-yoast-faq-block"><div class="schema-faq-section" id="faq-question-1631739467917"><strong class="schema-faq-question">Any subs for cilantro? I really don&#8217;t like the taste. </strong> <p class="schema-faq-answer">You could use parsley, but it would definitely lend a different flavor. You can always just omit the cilantro!</p> </div> <div class="schema-faq-section" id="faq-question-1631739533126"><strong class="schema-faq-question">How long will the sauce last in the fridge?</strong> <p class="schema-faq-answer">3-4 days in a sealed container! </p> </div> <div class="schema-faq-section" id="faq-question-1631739584891"><strong class="schema-faq-question">I can&#8217;t find cotija cheese. What should I use instead?</strong> <p class="schema-faq-answer">You could use another salty crumbled cheese like feta, or just omit! They are just as delicious without cheese.</p> </div> <div class="schema-faq-section" id="faq-question-1679513846597"><strong class="schema-faq-question">Any shortcut ideas to make this recipe even easier?</strong> <p class="schema-faq-answer">Buy storebought taco seasoning in place of the dried spices, buy shrimp that already peeled/deveined, and/or use a similar storebought sauce or dressing for the slaw!</p> </div> <div class="schema-faq-section" id="faq-question-1679513938526"><strong class="schema-faq-question">Can I fry the shrimp in this recipe?</strong> <p class="schema-faq-answer">Yes! The <a href="https://pinchofyum.com/crispy-fish-tacos-jalapeno-sauce" target="_blank" rel="noreferrer noopener">beer batter instructions in this recipe </a>work for shrimp, too! </p> </div> <div class="schema-faq-section" id="faq-question-1679513979002"><strong class="schema-faq-question">Could I use a different type of seafood than shrimp?</strong> <p class="schema-faq-answer">Sure could! Something simple like cod fillets, halibut, or mahi mahi would work great and have a similar flavor profile. This is my favorite <a href="https://pinchofyum.com/best-easy-fish-tacos">easy fish taco recipe</a>!</p> </div> </div>
+
+
+
+<p class="wp-block-paragraph"></p>
+
+
+
+<div class="slick-email-capture"></div>
+
+
+
+<hr class="wp-block-separator has-alpha-channel-opacity" />
+
+
+
+<h2 class="wp-block-heading has-text-align-center" id="h-looking-for-more-dinner-ideas">Looking For More Dinner Ideas?</h2>
+
+
+
+<p class="has-text-align-center wp-block-paragraph"><a href="https://pinchofyum.com/dinner-ideas">Check out our collection of 30+ top dinner recipes!</a></p>
+
+
+<svg aria-hidden="true" style="position: absolute;width: 0;height: 0;overflow: hidden" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<symbol viewbox="5 5 54 50" id="wpt-star-full">
+<defs>
+<linearGradient id="tasty-recipes-clip-0">
+<stop stop-opacity="1" offset="0%" stop-color="currentColor"></stop>
+<stop stop-opacity="0" offset="0%"></stop>
+</linearGradient>
+</defs>
+<path d="m46.296296 51.906272-14.379945-9.431623-14.413639 9.380051 4.52636-16.590672-13.375018-10.80959 17.177389-.821975 6.147423-16.0607456 6.08985 16.0826626 17.174335.883504-13.413655 10.761608z" stroke="currentColor" stroke-width="2.5" />
+</symbol>
+</defs>
+</svg>
+<a class="button tasty-recipes-print-button tasty-recipes-no-print tasty-recipes-print-above-card" href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw/print/40894">Print</a><span class="tasty-recipes-jump-target" id="tasty-recipes-40894-jump-target" style="display:block;padding-top:2px;margin-top:-2px;"></span><div id="tasty-recipes-40894" data-tr-id="40894" class="tasty-recipes tasty-recipes-40894 tasty-recipes-display tasty-recipes-has-image" data-tasty-recipes-customization="primary-color.border-color">
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;"><defs><symbol id="tasty-recipes-icon-clock" width="24" height="24" viewBox="0 0 24 24"><title>clock</title> <desc>clock icon</desc><path d="M22 5.72l-4.6-3.86-1.29 1.53 4.6 3.86L22 5.72zM7.88 3.39L6.6 1.86 2 5.71l1.29 1.53 4.59-3.85zM12.5 8H11v6l4.75 2.85.75-1.23-4-2.37V8zM12 4c-4.97 0-9 4.03-9 9s4.02 9 9 9c4.97 0 9-4.03 9-9s-4.03-9-9-9zm0 16c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z" fill="currentColor" /></symbol><symbol id="tasty-recipes-icon-cutlery" width="24" height="24" viewBox="0 0 24 24"><title>cutlery</title> <desc>cutlery icon</desc><path d="M11 9H9V2H7v7H5V2H3v7c0 2.12 1.66 3.84 3.75 3.97V22h2.5v-9.03C11.34 12.84 13 11.12 13 9V2h-2v7zm5-3v8h2.5v8H21V2c-2.76 0-5 2.24-5 4z" fill="currentColor" /></symbol><symbol id="tasty-recipes-icon-flag" width="24" height="24" viewBox="0 0 24 24"><title>flag</title> <desc>flag icon</desc><path d="M14.4 6L14 4H5v17h2v-7h5.6l.4 2h7V6z" fill="currentColor"/></symbol><symbol id="tasty-recipes-icon-folder" width="24" height="24" viewBox="0 0 24 24"><title>folder</title> <desc>folder icon</desc><path d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z" fill="currentColor" /></symbol><symbol id="tasty-recipes-icon-instagram" viewBox="0 0 448 512"><title>instagram</title> <desc>instagram icon</desc><path fill="currentColor" d="M224.1 141c-63.6 0-114.9 51.3-114.9 114.9s51.3 114.9 114.9 114.9S339 319.5 339 255.9 287.7 141 224.1 141zm0 189.6c-41.1 0-74.7-33.5-74.7-74.7s33.5-74.7 74.7-74.7 74.7 33.5 74.7 74.7-33.6 74.7-74.7 74.7zm146.4-194.3c0 14.9-12 26.8-26.8 26.8-14.9 0-26.8-12-26.8-26.8s12-26.8 26.8-26.8 26.8 12 26.8 26.8zm76.1 27.2c-1.7-35.9-9.9-67.7-36.2-93.9-26.2-26.2-58-34.4-93.9-36.2-37-2.1-147.9-2.1-184.9 0-35.8 1.7-67.6 9.9-93.9 36.1s-34.4 58-36.2 93.9c-2.1 37-2.1 147.9 0 184.9 1.7 35.9 9.9 67.7 36.2 93.9s58 34.4 93.9 36.2c37 2.1 147.9 2.1 184.9 0 35.9-1.7 67.7-9.9 93.9-36.2 26.2-26.2 34.4-58 36.2-93.9 2.1-37 2.1-147.8 0-184.8zM398.8 388c-7.8 19.6-22.9 34.7-42.6 42.6-29.5 11.7-99.5 9-132.1 9s-102.7 2.6-132.1-9c-19.6-7.8-34.7-22.9-42.6-42.6-11.7-29.5-9-99.5-9-132.1s-2.6-102.7 9-132.1c7.8-19.6 22.9-34.7 42.6-42.6 29.5-11.7 99.5-9 132.1-9s102.7-2.6 132.1 9c19.6 7.8 34.7 22.9 42.6 42.6 11.7 29.5 9 99.5 9 132.1s2.7 102.7-9 132.1z"></path></symbol><symbol id="tasty-recipes-icon-pinterest" viewBox="0 0 384 512"><title>pinterest</title> <desc>pinterest icon</desc><path fill="currentColor" d="M204 6.5C101.4 6.5 0 74.9 0 185.6 0 256 39.6 296 63.6 296c9.9 0 15.6-27.6 15.6-35.4 0-9.3-23.7-29.1-23.7-67.8 0-80.4 61.2-137.4 140.4-137.4 68.1 0 118.5 38.7 118.5 109.8 0 53.1-21.3 152.7-90.3 152.7-24.9 0-46.2-18-46.2-43.8 0-37.8 26.4-74.4 26.4-113.4 0-66.2-93.9-54.2-93.9 25.8 0 16.8 2.1 35.4 9.6 50.7-13.8 59.4-42 147.9-42 209.1 0 18.9 2.7 37.5 4.5 56.4 3.4 3.8 1.7 3.4 6.9 1.5 50.4-69 48.6-82.5 71.4-172.8 12.3 23.4 44.1 36 69.3 36 106.2 0 153.9-103.5 153.9-196.8C384 71.3 298.2 6.5 204 6.5z" /></symbol><symbol id="tasty-recipes-icon-facebook" viewBox="0 0 448 512"><title>facebook</title> <desc>facebook icon</desc><path fill="currentColor" d="M400 32H48A48 48 0 0 0 0 80v352a48 48 0 0 0 48 48h137.25V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.27c-30.81 0-40.42 19.12-40.42 38.73V256h68.78l-11 71.69h-57.78V480H400a48 48 0 0 0 48-48V80a48 48 0 0 0-48-48z" /></symbol><symbol id="tasty-recipes-icon-print" width="24" height="24" viewBox="0 0 24 24"><title>print</title> <desc>print icon</desc><path d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z" fill="currentColor" /></symbol><symbol id="tasty-recipes-icon-squares" width="24" height="24" viewBox="0 0 24 24"><title>squares</title> <desc>squares icon</desc><path d="M22 9V7h-2V5c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-2h2v-2h-2v-2h2v-2h-2V9h2zm-4 10H4V5h14v14zM6 13h5v4H6zm6-6h4v3h-4zM6 7h5v5H6zm6 4h4v6h-4z" fill="currentColor" /></symbol><symbol id="tasty-recipes-icon-heart-regular" viewBox="0 0 512 512"><title>heart</title> <desc>heart icon</desc><path fill="currentColor" d="M458.4 64.3C400.6 15.7 311.3 23 256 79.3 200.7 23 111.4 15.6 53.6 64.3-21.6 127.6-10.6 230.8 43 285.5l175.4 178.7c10 10.2 23.4 15.9 37.6 15.9 14.3 0 27.6-5.6 37.6-15.8L469 285.6c53.5-54.7 64.7-157.9-10.6-221.3zm-23.6 187.5L259.4 430.5c-2.4 2.4-4.4 2.4-6.8 0L77.2 251.8c-36.5-37.2-43.9-107.6 7.3-150.7 38.9-32.7 98.9-27.8 136.5 10.5l35 35.7 35-35.7c37.8-38.5 97.8-43.2 136.5-10.6 51.1 43.1 43.5 113.9 7.3 150.8z"></path></symbol><symbol id="tasty-recipes-icon-heart-solid" viewBox="0 0 512 512"><title>heart solid</title> <desc>heart solid icon</desc><path fill="currentColor" d="M462.3 62.6C407.5 15.9 326 24.3 275.7 76.2L256 96.5l-19.7-20.3C186.1 24.3 104.5 15.9 49.7 62.6c-62.8 53.6-66.1 149.8-9.9 207.9l193.5 199.8c12.5 12.9 32.8 12.9 45.3 0l193.5-199.8c56.3-58.1 53-154.3-9.8-207.9z"></path></symbol></defs></svg>
+<header class="tasty-recipes-entry-header" data-tasty-recipes-customization="primary-color.background">
+			<div class="tasty-recipes-image">
+			<img loading="lazy" decoding="async" data-tasty-recipes-customization="primary-color.border-color" width="400" height="400" src="https://pinchofyum.com/tachyon/Shrimp-Tacos-with-Slaw-Square.jpg?resize=400%2C400" class="attachment-featured-medium size-featured-medium" alt="Shrimp tacos with slaw." data-pin-nopin="nopin" data-pin-url="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?tp_image_id=54973" />		</div>
+		<h2 class="tasty-recipes-title" data-tasty-recipes-customization="h2-color.color h2-transform.text-transform">Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw</h2>
+	<hr data-tasty-recipes-customization="secondary-color.border-color secondary-color.background-color">
+			<div class="tasty-recipes-rating">
+							<p><svg aria-hidden="true" style="position: absolute;width: 0;height: 0;overflow: hidden" xmlns="http://www.w3.org/2000/svg">
+<defs>
+<symbol viewbox="5 5 54 50" id="wpt-star-full">
+<defs>
+<linearGradient id="tasty-recipes-clip-0">
+<stop stop-opacity="1" offset="0%" stop-color="currentColor"></stop>
+<stop stop-opacity="0" offset="0%"></stop>
+</linearGradient>
+</defs>
+<path d="m46.296296 51.906272-14.379945-9.431623-14.413639 9.380051 4.52636-16.590672-13.375018-10.80959 17.177389-.821975 6.147423-16.0607456 6.08985 16.0826626 17.174335.883504-13.413655 10.761608z" stroke="currentColor" stroke-width="2.5" />
+</symbol>
+</defs>
+</svg>
+<span class="tasty-recipes-ratings-buttons tasty-recipes-no-ratings-buttons"	data-tr-default-rating="4.8"	>		<span class="tasty-recipes-rating" data-tr-checked="1">		<i class="checked" data-rating="5">			<span class="tasty-recipes-rating-outline" data-tr-clip="80">				<svg xmlns="http://www.w3.org/2000/svg" viewbox="5 5 54 50" width="18" height="17"><defs><linearGradient id="tasty-recipes-clip-0"><stop stop-opacity="1" offset="0%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient><linearGradient id="tasty-recipes-clip-10"><stop stop-opacity="1" offset="10%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient><linearGradient id="tasty-recipes-clip-20"><stop stop-opacity="1" offset="20%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient><linearGradient id="tasty-recipes-clip-30"><stop stop-opacity="1" offset="30%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient><linearGradient id="tasty-recipes-clip-40"><stop stop-opacity="1" offset="40%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient><linearGradient id="tasty-recipes-clip-50"><stop stop-opacity="1" offset="50%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient><linearGradient id="tasty-recipes-clip-60"><stop stop-opacity="1" offset="60%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient><linearGradient id="tasty-recipes-clip-70"><stop stop-opacity="1" offset="70%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient><linearGradient id="tasty-recipes-clip-80"><stop stop-opacity="1" offset="80%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient><linearGradient id="tasty-recipes-clip-90"><stop stop-opacity="1" offset="90%" stop-color="currentColor"></stop><stop stop-opacity="0" offset="0%"></stop></linearGradient></defs><path d="m46.296296 51.906272-14.379945-9.431623-14.413639 9.380051 4.52636-16.590672-13.375018-10.80959 17.177389-.821975 6.147423-16.0607456 6.08985 16.0826626 17.174335.883504-13.413655 10.761608z" stroke="currentColor" stroke-width="2.5" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				5 Stars			</span>		</i>	</span>		<span class="tasty-recipes-rating" >		<i class="checked" data-rating="4">			<span class="tasty-recipes-rating-outline" data-tr-clip="100">				<svg class="tasty-recipes-svg" width="18" height="17"><use href="#wpt-star-full" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				4 Stars			</span>		</i>	</span>		<span class="tasty-recipes-rating" >		<i class="checked" data-rating="3">			<span class="tasty-recipes-rating-outline" data-tr-clip="100">				<svg class="tasty-recipes-svg" width="18" height="17"><use href="#wpt-star-full" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				3 Stars			</span>		</i>	</span>		<span class="tasty-recipes-rating" >		<i class="checked" data-rating="2">			<span class="tasty-recipes-rating-outline" data-tr-clip="100">				<svg class="tasty-recipes-svg" width="18" height="17"><use href="#wpt-star-full" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				2 Stars			</span>		</i>	</span>		<span class="tasty-recipes-rating" >		<i class="checked" data-rating="1">			<span class="tasty-recipes-rating-outline" data-tr-clip="100">				<svg class="tasty-recipes-svg" width="18" height="17"><use href="#wpt-star-full" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				1 Star			</span>		</i>	</span></span></p>
+										<p><span data-tasty-recipes-customization="detail-label-color.color" class="rating-label"><span class="average">4.8</span> from <span class="count">312</span> reviews</span></p>
+					</div>
+				<div class="tasty-recipes-details">
+			<ul>
+																<li class="author"><span class="tasty-recipes-label" data-tasty-recipes-customization="detail-label-color.color">
+														Author:</span> <a data-tasty-recipes-customization="detail-value-color.color" class="tasty-recipes-author-name" href="https://pinchofyum.com/about">Pinch of Yum</a>						</li>
+																																											<li class="total-time"><span class="tasty-recipes-label" data-tasty-recipes-customization="detail-label-color.color">
+																<svg viewBox="0 0 24 24" class="detail-icon" aria-hidden="true"><use href="#tasty-recipes-icon-clock" data-tasty-recipes-customization="icon-color.color"></use></svg>
+																Total Time:</span> <span data-tasty-recipes-customization="detail-value-color.color" class="tasty-recipes-total-time">30 minutes</span>						</li>
+																							<li class="yield"><span class="tasty-recipes-label" data-tasty-recipes-customization="detail-label-color.color">
+																<svg viewBox="0 0 24 24" class="detail-icon" aria-hidden="true"><use href="#tasty-recipes-icon-cutlery" data-tasty-recipes-customization="icon-color.color"></use></svg>
+																Yield:</span> <span data-tasty-recipes-customization="detail-value-color.color" class="tasty-recipes-yield"><span data-amount="4">4</span> (2 small tacos each) <span class="tasty-recipes-yield-scale"><span data-amount="1">1</span>x</span></span>						</li>
+																																												</ul>
+		</div>
+	</header>
+
+<div class="tasty-recipes-entry-content">
+
+		<div class="tasty-recipes-buttons">
+				<div class="tasty-recipes-button-wrap">
+			
+<a class="button tasty-recipes-print-button tasty-recipes-no-print" href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw/print/40894" rel="nofollow" target="_blank" data-tasty-recipes-customization="">
+			<svg viewBox="0 0 24 24" class="svg-print" aria-hidden="true"><use xlink:href="#tasty-recipes-icon-print"></use></svg>
+		Print</a>
+		</div>
+						<div class="tasty-recipes-button-wrap">
+			
+<a class="share-pin button" data-pin-custom="true" data-href="https://www.pinterest.com/pin/create/bookmarklet/?url=https%3A%2F%2Fpinchofyum.com%2Fspicy-shrimp-tacos-with-garlic-cilantro-lime-slaw" href="https://www.pinterest.com/pin/create/bookmarklet/?url=https%3A%2F%2Fpinchofyum.com%2Fspicy-shrimp-tacos-with-garlic-cilantro-lime-slaw" data-tasty-recipes-customization="">
+			<svg viewBox="0 0 24 24" class="svg-print" aria-hidden="true"><use xlink:href="#tasty-recipes-icon-pinterest"></use></svg>
+		Pin</a>
+<script>
+	const share_pin_buttons = document.getElementsByClassName( 'share-pin button' );
+	if ( share_pin_buttons ) {
+		for ( let share_key = 0; share_key < share_pin_buttons.length; share_key++ ) {
+			share_pin_buttons[share_key].addEventListener( 'click', (e) => {
+				e.stopPropagation();
+				window.open(e.target.dataset.href,'targetWindow','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=500,height=500');
+				return false;
+			} );
+		}
+	}
+</script>
+		</div>
+			</div>
+	
+			<div class="tasty-recipes-description">
+			<h3 data-tasty-recipes-customization="h3-color.color h3-transform.text-transform">Description</h3>
+			<div class="tasty-recipes-description-body" data-tasty-recipes-customization="body-color.color">
+				<p>The BEST Shrimp Tacos with Garlic Cilantro Lime Slaw &#8211; ready in about 30 minutes and loaded with flavor and texture. SO YUM!</p>
+			</div>
+		</div>
+	
+			<hr data-tasty-recipes-customization="secondary-color.border-color secondary-color.background-color">
+	
+			<div class="tasty-recipes-ingredients">
+			<div class="tasty-recipes-ingredients-header">
+				<div class="tasty-recipes-ingredients-clipboard-container">
+					<h3 data-tasty-recipes-customization="h3-color.color h3-transform.text-transform">Ingredients</h3>
+									</div>
+				<div class="tasty-recipes-units-scale-container"><span class="tasty-recipes-convert-container">
+						<span class="tasty-recipes-convert-label">Units</span>
+						<button class="tasty-recipes-convert-button tasty-recipes-convert-button-active" data-unit-type="usc" type="button">US</button><button class="tasty-recipes-convert-button" data-unit-type="metric" type="button">M</button>
+					</span><span class="tasty-recipes-scale-container">
+						<span class="tasty-recipes-scale-label">Scale</span>
+						<button class="tasty-recipes-scale-button" data-amount="0.5" type="button">1/2x</button><button class="tasty-recipes-scale-button tasty-recipes-scale-button-active" data-amount="1" type="button">1x</button><button class="tasty-recipes-scale-button" data-amount="2" type="button">2x</button>
+					</span>
+					</span></div>			</div>
+			<div data-tasty-recipes-customization="body-color.color">
+				<h4>Garlic Cilantro Lime Sauce:</h4>
+<ul>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047bc6" id="ingredient_checkbox_6a61869047bc6" aria-label="1/4 cup oil"><label for="ingredient_checkbox_6a61869047bc6"></label></span><span class="nutrifox-quantity" data-nf-original="usc" data-nf-usc="0.25" data-nf-metric="59.25" data-unit="cup" data-nf-usc-unit="cup" data-nf-metric-unit="ml" data-nf-food-id="682" data-nf-food-description="Vegetable oil, palm kernel" data-amount="0.25">1/4</span> <span class="nutrifox-unit" data-nf-original="usc" data-nf-usc="cup" data-nf-metric="ml" data-nf-food-id="682" data-nf-food-description="Vegetable oil, palm kernel">cup</span> <strong>oil</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047bd8" id="ingredient_checkbox_6a61869047bd8" aria-label="1/2 cup chopped green onions"><label for="ingredient_checkbox_6a61869047bd8"></label></span><span class="nutrifox-quantity" data-nf-original="usc" data-nf-usc="0.5" data-nf-metric="35.5" data-unit="cup" data-nf-usc-unit="cup" data-nf-metric-unit="gram" data-nf-food-id="3040" data-nf-food-description="Onions, young green, tops only" data-amount="0.5">1/2</span> <span class="nutrifox-unit" data-nf-original="usc" data-nf-usc="cup" data-nf-metric="gram" data-nf-food-id="3040" data-nf-food-description="Onions, young green, tops only">cup</span> chopped <strong>green onions</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047be5" id="ingredient_checkbox_6a61869047be5" aria-label="1/2 cup cilantro leaves"><label for="ingredient_checkbox_6a61869047be5"></label></span><span class="nutrifox-quantity" data-nf-original="usc" data-nf-usc="0.5" data-nf-metric="8" data-unit="cup" data-nf-usc-unit="cup" data-nf-metric-unit="gram" data-nf-food-id="2931" data-nf-food-description="Coriander (cilantro) leaves, raw" data-amount="0.5">1/2</span> <span class="nutrifox-unit" data-nf-original="usc" data-nf-usc="cup" data-nf-metric="gram" data-nf-food-id="2931" data-nf-food-description="Coriander (cilantro) leaves, raw">cup</span> <strong>cilantro leaves</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047bec" id="ingredient_checkbox_6a61869047bec" aria-label="2 cloves garlic"><label for="ingredient_checkbox_6a61869047bec"></label></span><span data-amount="2">2</span> cloves <strong>garlic</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047bf3" id="ingredient_checkbox_6a61869047bf3" aria-label="1/2 teaspoon salt"><label for="ingredient_checkbox_6a61869047bf3"></label></span><span data-amount="0.5" data-unit="teaspoon">1/2 teaspoon</span> <strong>salt</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047bf9" id="ingredient_checkbox_6a61869047bf9" aria-label="juice of 2 limes"><label for="ingredient_checkbox_6a61869047bf9"></label></span>juice of <span data-amount="2">2</span> <strong>limes</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c06" id="ingredient_checkbox_6a61869047c06" aria-label="1/2 cup sour cream or full-fat Greek yogurt"><label for="ingredient_checkbox_6a61869047c06"></label></span><span class="nutrifox-quantity" data-nf-original="usc" data-nf-usc="0.5" data-nf-metric="142.5" data-unit="cup" data-nf-usc-unit="cup" data-nf-metric-unit="gram" data-nf-food-id="240" data-nf-food-description="Yogurt, Greek, plain, whole milk" data-amount="0.5">1/2</span> <span class="nutrifox-unit" data-nf-original="usc" data-nf-usc="cup" data-nf-metric="gram" data-nf-food-id="240" data-nf-food-description="Yogurt, Greek, plain, whole milk">cup</span> <strong>sour cream</strong> or <strong>full-fat Greek yogurt</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c12" id="ingredient_checkbox_6a61869047c12" aria-label="1/4 cup water (if needed, to thin sauce)"><label for="ingredient_checkbox_6a61869047c12"></label></span><span class="nutrifox-quantity" data-nf-original="usc" data-nf-usc="0.25" data-nf-metric="59.25" data-unit="cup" data-nf-usc-unit="cup" data-nf-metric-unit="ml" data-nf-food-id="4384" data-nf-food-description="Beverages, water, tap, drinking" data-amount="0.25">1/4</span> <span class="nutrifox-unit" data-nf-original="usc" data-nf-usc="cup" data-nf-metric="ml" data-nf-food-id="4384" data-nf-food-description="Beverages, water, tap, drinking">cup</span> <strong>water </strong><em>(if needed, to thin sauce)</em></li>
+</ul>
+<h4>Shrimp Taco Spice Mix:</h4>
+<ul>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c1b" id="ingredient_checkbox_6a61869047c1b" aria-label="2 teaspoons each chili powder and cumin"><label for="ingredient_checkbox_6a61869047c1b"></label></span><span data-amount="2" data-unit="teaspoon">2 teaspoons</span> <em><strong>each</strong> </em><strong>chili powder</strong> and <strong>cumin</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c24" id="ingredient_checkbox_6a61869047c24" aria-label="1/2 teaspoon each onion powder and garlic powder"><label for="ingredient_checkbox_6a61869047c24"></label></span><span data-amount="0.5" data-unit="teaspoon">1/2 teaspoon</span> <em><strong>each</strong></em> <strong>onion powder</strong> and <strong>garlic powder</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c2a" id="ingredient_checkbox_6a61869047c2a" aria-label="1/4 teaspoon cayenne pepper (more or less to taste)"><label for="ingredient_checkbox_6a61869047c2a"></label></span><span data-amount="0.25" data-unit="teaspoon">1/4 teaspoon</span> <strong>cayenne pepper</strong> (more or less to taste)</li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c30" id="ingredient_checkbox_6a61869047c30" aria-label="1 teaspoon coarse sea salt"><label for="ingredient_checkbox_6a61869047c30"></label></span><span data-amount="1" data-unit="teaspoon">1 teaspoon</span> <strong>coarse sea salt</strong></li>
+</ul>
+<h4>Stuff for the Shrimp Tacos:</h4>
+<ul>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c43" id="ingredient_checkbox_6a61869047c43" aria-label="1 lb. large shrimp, peeled and deveined, tails removed"><label for="ingredient_checkbox_6a61869047c43"></label></span><span class="nutrifox-quantity" data-nf-original="usc" data-nf-usc="1" data-nf-metric="453.333" data-unit="lb" data-nf-usc-unit="lb" data-nf-metric-unit="gram" data-nf-food-id="4739" data-nf-food-description="Crustaceans, shrimp, raw (not previously frozen)" data-amount="1">1</span> <span class="nutrifox-unit" data-nf-original="usc" data-nf-usc="lb" data-nf-metric="g" data-nf-food-id="4739" data-nf-food-description="Crustaceans, shrimp, raw (not previously frozen)">lb</span>. <strong>large shrimp</strong>, peeled and deveined, tails removed</li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c51" id="ingredient_checkbox_6a61869047c51" aria-label="2-3 cups shredded green cabbage"><label for="ingredient_checkbox_6a61869047c51"></label></span><span class="nutrifox-quantity" data-nf-original="usc" data-nf-usc="2" data-nf-metric="178" data-unit="cup" data-nf-usc-unit="cup" data-nf-metric-unit="gram" data-nf-food-id="2888" data-nf-food-description="Cabbage, raw" data-amount="2">2</span>&#8211;<span class="nutrifox-second-quantity" data-nf-original="usc" data-nf-usc="3" data-nf-metric="267" data-unit="cup" data-nf-usc-unit="cup" data-nf-metric-unit="gram" data-nf-food-id="2888" data-nf-food-description="Cabbage, raw" data-amount="3">3</span> <span class="nutrifox-unit" data-nf-original="usc" data-nf-usc="cup" data-nf-metric="gram" data-nf-food-id="2888" data-nf-food-description="Cabbage, raw">cups</span> shredded <strong>green cabbage</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c5d" id="ingredient_checkbox_6a61869047c5d" aria-label="8 small tortillas (corn or flour)"><label for="ingredient_checkbox_6a61869047c5d"></label></span><span data-amount="8">8</span> small <strong>tortillas</strong> (corn or flour)</li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c63" id="ingredient_checkbox_6a61869047c63" aria-label="2 avocados"><label for="ingredient_checkbox_6a61869047c63"></label></span><span data-amount="2">2</span> <strong>avocados</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c6e" id="ingredient_checkbox_6a61869047c6e" aria-label="1/4 cup Cotija cheese"><label for="ingredient_checkbox_6a61869047c6e"></label></span><span class="nutrifox-quantity" data-nf-original="usc" data-nf-usc="0.25" data-nf-metric="30" data-unit="cup" data-nf-usc-unit="cup" data-nf-metric-unit="gram" data-nf-food-id="224" data-nf-food-description="Cheese, mexican, queso cotija" data-amount="0.25">1/4</span> <span class="nutrifox-unit" data-nf-original="usc" data-nf-usc="cup" data-nf-metric="gram" data-nf-food-id="224" data-nf-food-description="Cheese, mexican, queso cotija">cup</span> <strong>Cotija cheese</strong></li>
+<li data-tr-ingredient-checkbox=""><span class="tr-ingredient-checkbox-container"><input type="checkbox" name="ingredient_checkbox_6a61869047c73" id="ingredient_checkbox_6a61869047c73" aria-label="lime wedges for serving"><label for="ingredient_checkbox_6a61869047c73"></label></span><strong>lime wedges</strong> for serving</li>
+</ul>			</div>
+			<div class="tasty-recipes-cook-mode">
+	<div class="tasty-recipes-cook-mode__container">
+		<label class="tasty-recipes-cook-mode__switch">
+			<input type="checkbox" id="tasty_recipes_6a618690483fb_cookmode">
+			<span class="tasty-recipes-cook-mode__switch-slider tasty-recipes-cook-mode__switch-round"
+				data-tasty-recipes-customization="button-color.background button-text-color.color"></span>
+		</label>
+		<label for="tasty_recipes_6a618690483fb_cookmode">
+			<span class="tasty-recipes-cook-mode__label">Cook Mode</span>
+			<span class="tasty-recipes-cook-mode__helper">
+				Prevent your screen from going dark			</span>
+		</label>
+	</div>
+</div>
+		</div>
+	
+			<hr data-tasty-recipes-customization="secondary-color.border-color secondary-color.background-color">
+	
+		<div class="tasty-recipes-instructions">
+		<div class="tasty-recipes-instructions-header">
+			<h3 data-tasty-recipes-customization="h3-color.color h3-transform.text-transform">Instructions</h3>
+						<div class="tasty-recipes-video-toggle-container">
+				<label for="tasty-recipes-video-toggle">Video</label>
+				<button type="button" role="switch" aria-checked="true" name="tasty-recipes-video-toggle">
+					<span>On</span>
+					<span>Off</span>
+				</button>
+			</div>
+					</div>
+		<div data-tasty-recipes-customization="body-color.color">
+			<ol>
+<li id="instruction-step-1"><strong>Sauce:</strong> Pulse all the sauce ingredients in a food processor or blender until mostly smooth. Add water if needed to thin.<br /><div class="tasty-recipe-responsive-iframe-container" style="aspect-ratio: 16 / 9;"><iframe loading="lazy" class="fitvidsignore" title="Spicy Shrimp Tacos Step 1" src="https://player.vimeo.com/video/418600899?dnt=1&amp;app_id=122963&#038;autoplay=0&#038;muted=1&#038;autopause=0&#038;loop=1&#038;controls=1"   frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe></div></li>
+<li id="instruction-step-2"><strong>Slaw:</strong> Toss some of the sauce (not all) with the cabbage. We&#8217;ll use the leftover sauce to top the tacos.<br /><div class="tasty-recipe-responsive-iframe-container" style="aspect-ratio: 16 / 9;"><iframe loading="lazy" class="fitvidsignore" title="Spicy Shrimp Tacos Step 2" src="https://player.vimeo.com/video/418601052?dnt=1&amp;app_id=122963&#038;autoplay=0&#038;muted=1&#038;autopause=0&#038;loop=1&#038;controls=1"   frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe></div></li>
+<li id="instruction-step-3"><strong>Shrimp: </strong>Pat the shrimp dry with paper towels. Toss the shrimp in a small bowl with the spice mix to get it coated. Heat a drizzle of oil a large skillet over medium high heat. Add the shrimp to the hot pan and sauté for 5-8 minutes, flipping occasionally, until the shrimp are cooked through.<br /><div class="tasty-recipe-responsive-iframe-container" style="aspect-ratio: 16 / 9;"><iframe loading="lazy" class="fitvidsignore" title="Spicy Shrimp Tacos Step 3" src="https://player.vimeo.com/video/418601228?dnt=1&amp;app_id=122963&#038;autoplay=0&#038;muted=1&#038;autopause=0&#038;loop=1&#038;controls=1"   frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe></div></li>
+<li id="instruction-step-4"><strong>Assembly</strong>: For the prettiest and easiest-to-eat assembly, go in this order: smashed avocado, slaw, and shrimp. Finish with Cotjia cheese, lime wedges, and extra sauce.<br /><div class="tasty-recipe-responsive-iframe-container" style="aspect-ratio: 16 / 9;"><iframe loading="lazy" class="fitvidsignore" title="Spicy Shrimp Tacos Step 4" src="https://player.vimeo.com/video/418601483?dnt=1&amp;app_id=122963&#038;autoplay=0&#038;muted=1&#038;autopause=0&#038;loop=1&#038;controls=1"   frameborder="0" allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share" referrerpolicy="strict-origin-when-cross-origin"></iframe></div></li>
+</ol>
+		</div>
+	</div>
+	
+	
+		
+			<div class="tasty-recipes-equipment">
+			<h3 data-tasty-recipes-customization="h3-color.color h3-transform.text-transform">Equipment</h3>
+				<article class="tasty-link-card">
+		<a class="tasty-link" rel="nofollow noopener" target="_blank" href="https://www.target.com/p/cuisinart-custom-14-cup-food-processor-brushed-stainless-steel-dfp-14bcny/-/A-53911388#lnk=sametab"><img loading="lazy" decoding="async" width="300" height="300" src="https://pinchofyum.com/tachyon/food-processor-cuisinart.webp?fit=300%2C300" class="attachment-300x300 size-300x300 wp-post-image" alt="food processor cuisinart" data-pin-nopin="nopin" data-pin-url="https://pinchofyum.com/?tasty_link=food-processor&amp;tp_image_id=95279" /></a><p><a class="tasty-link" rel="nofollow noopener" target="_blank" href="https://www.target.com/p/cuisinart-custom-14-cup-food-processor-brushed-stainless-steel-dfp-14bcny/-/A-53911388#lnk=sametab">Food Processor</a></p>
+<span><a class="tasty-link" rel="nofollow noopener" target="_blank" href="https://www.target.com/p/cuisinart-custom-14-cup-food-processor-brushed-stainless-steel-dfp-14bcny/-/A-53911388#lnk=sametab">Buy Now →</a></span>			</article>
+		<article class="tasty-link-card">
+		<a class="tasty-link" rel="nofollow noopener" target="_blank" href="https://amzn.to/4h7rPS8"><img loading="lazy" decoding="async" src="https://m.media-amazon.com/images/I/31wQZWNJiZL._SL500_.jpg" height="500" width="500" class="attachment-thumbnail tasty-links-image-url" data-pin-nopin="true" alt="Image of Large Skillet"></a><p><a class="tasty-link" rel="nofollow noopener" target="_blank" href="https://amzn.to/4h7rPS8">Large Skillet</a></p>
+<span><a class="tasty-link" rel="nofollow noopener" target="_blank" href="https://amzn.to/4h7rPS8">Buy Now →</a></span>			</article>
+		<article class="tasty-link-card">
+		<a class="tasty-link" rel="nofollow noopener" target="_blank" href="https://www.target.com/p/oxo-3pc-insulated-stainless-steel-mixing-bowl-set-gray/-/A-79652868#lnk=sametab"><img loading="lazy" decoding="async" src="https://target.scene7.com/is/image/Target/GUEST_1daa615b-0021-427b-95cf-dc996a66dbe6?wid=1200&amp;hei=1200&amp;qlt=80&amp;fmt=webp" height="250" width="250" class="attachment-thumbnail tasty-links-image-url" data-pin-nopin="true" alt="Image of Stainless Steel Mixing Bowl"></a><p><a class="tasty-link" rel="nofollow noopener" target="_blank" href="https://www.target.com/p/oxo-3pc-insulated-stainless-steel-mixing-bowl-set-gray/-/A-79652868#lnk=sametab">Stainless Steel Mixing Bowl</a></p>
+<span><a class="tasty-link" rel="nofollow noopener" target="_blank" href="https://www.target.com/p/oxo-3pc-insulated-stainless-steel-mixing-bowl-set-gray/-/A-79652868#lnk=sametab">Buy Now →</a></span>			</article>
+	<div class="tasty-links-disclaimer">The equipment section may contain affiliate links to products we know and love.</div>		</div>
+	
+	
+			<div class="tasty-recipes-other-details" data-tasty-recipes-customization="secondary-color.background-color">
+			<ul>
+				<li class="prep-time"><span class="tasty-recipes-label" data-tasty-recipes-customization="detail-label-color.color"><svg viewbox="0 0 24 24" class="detail-icon" aria-hidden="true" data-tasty-recipes-customization="icon-color.color"><use href="#tasty-recipes-icon-clock"></use></svg>Prep Time:</span> <span data-tasty-recipes-customization="detail-value-color.color" class="tasty-recipes-prep-time">20 mins</span></li><li class="cook-time"><span class="tasty-recipes-label" data-tasty-recipes-customization="detail-label-color.color"><svg viewbox="0 0 24 24" class="detail-icon" aria-hidden="true" data-tasty-recipes-customization="icon-color.color"><use href="#tasty-recipes-icon-clock"></use></svg>Cook Time:</span> <span data-tasty-recipes-customization="detail-value-color.color" class="tasty-recipes-cook-time">10 mins</span></li><li class="category"><span class="tasty-recipes-label" data-tasty-recipes-customization="detail-label-color.color"><svg viewbox="0 0 24 24" class="detail-icon" aria-hidden="true" data-tasty-recipes-customization="icon-color.color"><use href="#tasty-recipes-icon-folder"></use></svg>Category:</span> <span data-tasty-recipes-customization="detail-value-color.color" class="tasty-recipes-category">Dinner</span></li><li class="method"><span class="tasty-recipes-label" data-tasty-recipes-customization="detail-label-color.color"><svg viewbox="0 0 24 24" class="detail-icon" aria-hidden="true" data-tasty-recipes-customization="icon-color.color"><use href="#tasty-recipes-icon-squares"></use></svg>Method:</span> <span data-tasty-recipes-customization="detail-value-color.color" class="tasty-recipes-method">Sauté</span></li><li class="cuisine"><span class="tasty-recipes-label" data-tasty-recipes-customization="detail-label-color.color"><svg viewbox="0 0 24 24" class="detail-icon" aria-hidden="true" data-tasty-recipes-customization="icon-color.color"><use href="#tasty-recipes-icon-flag"></use></svg>Cuisine:</span> <span data-tasty-recipes-customization="detail-value-color.color" class="tasty-recipes-cuisine">Mexican</span></li>			</ul>
+		</div>
+	
+	
+			<div class="tasty-recipes-nutrifox">
+			<iframe title="nutritional information" id="nutrifox-label-19303" src="https://nutrifox.com/embed/label/19303" style="width:100%;border-width:0;"></iframe>		</div>
+	
+	
+			<div class="tasty-recipes-keywords" data-tasty-recipes-customization="secondary-color.background-color">
+			<p data-tasty-recipes-customization="detail-value-color.color"><span class="tasty-recipes-label" data-tasty-recipes-customization="detail-label-color.color">Keywords:</span> spicy shrimp tacos, shrimp taco recipe, garlic lime slaw</p>
+		</div>
+	
+	<footer class="tasty-recipes-entry-footer" data-tasty-recipes-customization="primary-color.background">
+		<div class="tasty-recipes-footer-content">
+						<div class="tasty-recipes-footer-copy">
+				<h3 data-tasty-recipes-customization="footer-heading-color.color h3-transform.text-transform footer-heading.innerText">Did you make this recipe?</h3>
+				<div data-tasty-recipes-customization="footer-description-color.color footer-description.innerHTML"><div id="C034LLD58BE-1762880169.627349-thread-list-Thread_1762880256.293149" class="c-virtual_list__item" role="listitem" data-qa="virtual-list-item" data-item-key="1762880256.293149">
+<div class="c-message_kit__background c-message_kit__message c-message_kit__thread_message" role="presentation" data-qa="message_container" data-qa-unprocessed="false" data-qa-placeholder="false">
+<div class="c-message_kit__hover" role="document" data-qa-hover="true">
+<div class="c-message_kit__actions c-message_kit__actions--default">
+<div class="c-message_kit__gutter">
+<div class="c-message_kit__gutter__right" role="presentation" data-qa="message_content">
+<div class="c-message_kit__blocks c-message_kit__blocks--rich_text">
+<div class="c-message__message_blocks c-message__message_blocks--rich_text" data-qa="message-text">
+<div class="p-block_kit_renderer" data-qa="block-kit-renderer">
+<div class="p-block_kit_renderer__block_wrapper p-block_kit_renderer__block_wrapper--first">
+<div class="p-rich_text_block" dir="auto">
+<div class="p-rich_text_section">I love hearing from you! Leave a comment or rating below!</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+			</div>
+		</div>
+	</footer>
+</div>
+
+
+</div>
+
+
+<h2 class="wp-block-heading" id="h-more-favorite-taco-recipes-to-love">More Favorite Taco Recipes To Love</h2>
+
+
+
+<ul class="wp-block-list">
+<li><a href="https://pinchofyum.com/crispy-black-bean-tacos-with-cilantro-lime-sauce">Crispy Black Bean Tacos with Cilantro Lime Sauce</a></li>
+
+
+
+<li><a href="https://pinchofyum.com/best-easy-fish-tacos">Best Easy Fish Tacos</a></li>
+
+
+
+<li><a href="https://pinchofyum.com/instant-pot-buffalo-chicken-tacos">Instant Pot Buffalo Chicken Tacos</a></li>
+
+
+
+<li><a href="https://pinchofyum.com/instant-pot-hawaiian-chicken-tacos">Instant Pot Hawaiian Chicken Tacos with Jalapeño Ranch Slaw</a></li>
+
+
+
+<li><a href="https://pinchofyum.com/red-chile-chicken-tacos-with-creamy-corn">Red Chile Chicken Tacos with Creamy Corn</a></li>
+</ul>
+
+
+
+<hr class="wp-block-separator has-css-opacity is-style-wide" />
+
+
+
+<h2 class="wp-block-heading has-text-align-center">Time To Show You Off!</h2>
+
+
+
+<figure class="wp-block-image size-full"><img loading="lazy" width="1200" height="1378" decoding="async" data-pin-url="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?tp_image_id=61366" data-pin-description="The Best Shrimp Tacos with Garlic Cilantro Lime Slaw - ready in about 30 minutes and loaded with flavor and texture. SO YUM! #tacos #tacotuesday #shrimp" data-pin-title="Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw" src="https://pinchofyum.com/tachyon/Shrimp-Tacos-UGC.jpg" alt="Image collage of reader recipes of spicy shrimp tacos. " class="wp-image-61366" srcset="https://pinchofyum.com/tachyon/Shrimp-Tacos-UGC.jpg?resize=1200%2C1378&amp;zoom=1 1200w, https://pinchofyum.com/tachyon/Shrimp-Tacos-UGC.jpg?resize=1200%2C1378&amp;zoom=0.5 600w, https://pinchofyum.com/tachyon/Shrimp-Tacos-UGC.jpg?resize=1200%2C1378&amp;zoom=0.25 300w" sizes="(min-width: 1220px) 653px, (min-width: 780px) calc(51.67vw + 33px), calc(100vw - 32px)" /></figure>
+
+
+
+<hr class="wp-block-separator has-css-opacity is-style-wide" />
+
+
+
+<h2 class="wp-block-heading has-text-align-center">More Of Our Best Taco Recipes To Try</h2>
+
+
+
+<p class="has-text-align-center wp-block-paragraph">This recipe is part of our <a href="https://pinchofyum.com/best-taco-recipes">10 best taco recipes collection</a>. Try them all!</p>
+				</div>
+				<div class="filed-under tracking-wider font-sans flex items-center flex-wrap">
+					<strong>Filed Under:</strong> <a href="https://pinchofyum.com/recipes/all" rel="category tag">All Recipes</a> <a href="https://pinchofyum.com/recipes/avocado" rel="category tag">Avocado</a> <a href="https://pinchofyum.com/recipes/dinner" rel="category tag">Dinner</a> <a href="https://pinchofyum.com/recipes/fish" rel="category tag">Fish and Seafood</a> <a href="https://pinchofyum.com/recipes/lime" rel="category tag">Lime</a> <a href="https://pinchofyum.com/recipes/lunch" rel="category tag">Lunch</a> <a href="https://pinchofyum.com/recipes/main-dishes" rel="category tag">Main Dishes</a> <a href="https://pinchofyum.com/recipes/popular" rel="category tag">Most Popular</a> <a href="https://pinchofyum.com/recipes/quick-and-easy" rel="category tag">Quick and Easy</a> <a href="https://pinchofyum.com/recipes/sugar-free" rel="category tag">Sugar-Free</a> <a href="https://pinchofyum.com/recipes/summer" rel="category tag">Summer</a> <a href="https://pinchofyum.com/recipes/taco" rel="category tag">Tacos</a>				</div>
+				<div class="entry-footer">
+					<div class="py-4 text-center font-arvo font-bold tracking-widest uppercase text-sm text-gray-600">June 24, 2022</div>
+					<div class="grid grid-cols-2 border-t border-b my-4 py-4 md:my-6 md:py-6">
+		<div class="col-span-1 flex flex-wrap lg:flex-nowrap content-between">
+		<div class="lg:w-1/3">
+			<a href="https://pinchofyum.com/smash-burgers-with-house-sauce">
+				<img data-pin-description="The famous Smash Burger! Deeply crisped, craggy, juice, squashed patties covered with melty cheese, piled on a buttery bun, and topped with dreamy zip of secret sauce. #burger #smashburger" data-pin-title="Smash Burgers with House Sauce" width="183" height="183" src="https://pinchofyum.com/tachyon/Smash-burgers-2-2.jpg?resize=183%2C183" class="h-24 w-24 wp-post-image" alt="Hands holding a juicy smash burger with sauce." sizes="96px" decoding="async" loading="lazy" srcset="https://pinchofyum.com/tachyon/Smash-burgers-2-2.jpg?resize=183%2C183&amp;zoom=2 366w, https://pinchofyum.com/tachyon/Smash-burgers-2-2.jpg?resize=183%2C183&amp;zoom=1.5 275w, https://pinchofyum.com/tachyon/Smash-burgers-2-2.jpg?resize=183%2C183&amp;zoom=1 183w, https://pinchofyum.com/tachyon/Smash-burgers-2-2.jpg?resize=183%2C183&amp;zoom=0.5 92w, https://pinchofyum.com/tachyon/Smash-burgers-2-2.jpg?resize=183%2C183&amp;zoom=0.25 46w" data-pin-nopin="nopin" data-pin-url="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?tp_image_id=85025" />			</a>
+		</div>
+		<div class="lg:w-2/3 lg:flex lg:flex-wrap">
+			<h3 class="font-domaine text-lg lg:text-xl leading-none self-start my-2 lg:my-0"><a class="text-black" href="https://pinchofyum.com/smash-burgers-with-house-sauce">Smash Burgers with House Sauce</a></h3>
+			<a class="btn-small inline-block font-sans self-end" href="https://pinchofyum.com/smash-burgers-with-house-sauce">Prev</a>
+		</div>
+	</div>
+			<div class="col-span-1 flex flex-row-reverse flex-wrap lg:flex-nowrap content-between">
+		<div class="lg:w-1/3">
+			<a href="https://pinchofyum.com/smash-burgers-with-house-sauce">
+				<img data-pin-description="JUICY LUCY! A delicious hamburger stuffed with molten, bubbly, waterfalling cheese, all piled on a buttery toasted bun with all the fixings. The BEST. #burger #bbq #grilling | pinchofyum.com" width="183" height="183" src="https://pinchofyum.com/tachyon/Juicy-Lucy-Inside.jpg?resize=183%2C183" class="h-24 w-24 mr-0 ml-4 float-right md:float-none wp-post-image" alt="A picture of Juicy Lucy" sizes="96px" decoding="async" loading="lazy" srcset="https://pinchofyum.com/tachyon/Juicy-Lucy-Inside.jpg?resize=183%2C183&amp;zoom=2 366w, https://pinchofyum.com/tachyon/Juicy-Lucy-Inside.jpg?resize=183%2C183&amp;zoom=1.5 275w, https://pinchofyum.com/tachyon/Juicy-Lucy-Inside.jpg?resize=183%2C183&amp;zoom=1 183w, https://pinchofyum.com/tachyon/Juicy-Lucy-Inside.jpg?resize=183%2C183&amp;zoom=0.5 92w, https://pinchofyum.com/tachyon/Juicy-Lucy-Inside.jpg?resize=183%2C183&amp;zoom=0.25 46w" data-pin-nopin="nopin" data-pin-url="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?tp_image_id=53530" />			</a>
+		</div>
+		<div class="lg:w-2/3 lg:flex lg:flex-wrap lg:justify-end text-right">
+			<h3 class="font-domaine text-lg lg:text-xl leading-none text-right self-start my-2 lg:my-0"><a class="text-black" href="https://pinchofyum.com/juicy-lucy">Juicy Lucy</a></h3>
+			<a class="btn-small inline-block font-sans self-end" href="https://pinchofyum.com/juicy-lucy">Next</a>
+		</div>
+	</div>
+	</div>
+						<div class="py-6 author-card">
+		<div class="mb-4 lg:grid grid-cols-4">
+			<div class="col-span-1">
+				<img class="h-42 w-42 mx-auto rounded-full mb-6" alt="Lindsay Ostrom" data-pin-nopin="true" loading="lazy" height="192" width="192" src="https://pinchofyum.com/content/assets/images/sidebar/sidebar-lindsay.jpg">
+			</div>
+			<div class="mb-2 md:pl-6 col-span-3">
+				<h5 class="mb-4 lg:mt-0 mb-2 font-arvo tracking-widest uppercase text-black text-sm text-center lg:text-left">Nice to meet you!</h5>
+				<p class="mb-4 text-gray-600 text-center lg:text-left">I’m Lindsay and I ♡ FOOD. I used to be a teacher, and now making food and writing about it online is my full-time job. I love talking with people about food, and I'm so glad you're here.</p>
+				<p class="mb-4 text-gray-600 text-center lg:text-left">Did you make a recipe? Tag <a target="_blank" href="https://www.instagram.com/pinchofyum/" rel="noopener">@pinchofyum</a> on Instagram so we can find you!</p>
+				<div class="mt-2 mb-2 flex justify-center lg:justify-start space-x-4">
+										<a target="_blank" href="https://www.instagram.com/pinchofyum" rel="noopener"><svg class="w-8 h-8 p-1 text-white hover:bg-black bg-purple-500 rounded-full"><title>INSTAGRAM</title><desc>INSTAGRAM icon</desc><use xlink:href="#sprite-icon-instagram"></use></svg></a>
+										<a target="_blank" href="https://www.pinterest.com/pinchofyum/_created/" rel="noopener"><svg class="w-8 h-8 p-1 text-white hover:bg-black bg-purple-500 rounded-full"><title>PINTEREST</title><desc>PINTEREST icon</desc><use xlink:href="#sprite-icon-pinterest"></use></svg></a>
+										<a target="_blank" href="https://www.tiktok.com/@pinchofyum" rel="noopener"><svg class="w-8 h-8 p-1 text-white hover:bg-black bg-purple-500 rounded-full"><title>TIKTOK</title><desc>TIKTOK icon</desc><use xlink:href="#sprite-icon-tiktok"></use></svg></a>
+										<a target="_blank" href="https://www.facebook.com/pinchofyum" rel="noopener"><svg class="w-8 h-8 p-1 text-white hover:bg-black bg-purple-500 rounded-full"><title>FACEBOOK</title><desc>FACEBOOK icon</desc><use xlink:href="#sprite-icon-facebook"></use></svg></a>
+										<a target="_blank" href="https://twitter.com/pinchofyum" rel="noopener"><svg class="w-8 h-8 p-1 text-white hover:bg-black bg-purple-500 rounded-full"><title>TWITTER</title><desc>TWITTER icon</desc><use xlink:href="#sprite-icon-twitter"></use></svg></a>
+										<a target="_blank" href="https://www.youtube.com/pinchofyum" rel="noopener"><svg class="w-8 h-8 p-1 text-white hover:bg-black bg-purple-500 rounded-full"><title>YOUTUBE</title><desc>YOUTUBE icon</desc><use xlink:href="#sprite-icon-youtube"></use></svg></a>
+									</div>
+			</div>
+		</div>
+	</div>
+				</div>
+				
+<div id="comments">
+
+		<div id="respond" class="comment-respond">
+		<h3 id="reply-title" class="comment-reply-title">Leave a Reply <small><a rel="nofollow" id="cancel-comment-reply-link" href="/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#respond" style="display:none;">Cancel reply</a></small></h3><form action="https://pinchofyum.com/wp-comments-post.php" method="post" id="commentform" class="comment-form"><p class="comment-notes"><span id="email-notes">Your email address will not be published.</span> <span class="required-field-message">Required fields are marked <span class="required">*</span></span></p>		<fieldset class="tasty-recipes-ratings tasty-recipes-comment-form">
+			<legend>Recipe rating</legend>
+			<span class="tasty-recipes-ratings-buttons "	data-tr-default-rating="0"	>		<input		aria-label="Rate this recipe 5 stars"		type="radio"		name="tasty-recipes-rating"		class="tasty-recipes-rating"		id="tasty_recipes_rating_input_6a61869072f54"		value="5">		<span class="tasty-recipes-rating" >		<i class="checked" data-rating="5">			<span class="tasty-recipes-rating-outline" data-tr-clip="0">				<svg class="tasty-recipes-svg" width="18" height="17"><use href="#wpt-star-full" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				5 Stars			</span>		</i>	</span>		<input		aria-label="Rate this recipe 4 stars"		type="radio"		name="tasty-recipes-rating"		class="tasty-recipes-rating"		id="tasty_recipes_rating_input_6a61869073001"		value="4">		<span class="tasty-recipes-rating" >		<i class="checked" data-rating="4">			<span class="tasty-recipes-rating-outline" data-tr-clip="0">				<svg class="tasty-recipes-svg" width="18" height="17"><use href="#wpt-star-full" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				4 Stars			</span>		</i>	</span>		<input		aria-label="Rate this recipe 3 stars"		type="radio"		name="tasty-recipes-rating"		class="tasty-recipes-rating"		id="tasty_recipes_rating_input_6a61869073068"		value="3">		<span class="tasty-recipes-rating" >		<i class="checked" data-rating="3">			<span class="tasty-recipes-rating-outline" data-tr-clip="0">				<svg class="tasty-recipes-svg" width="18" height="17"><use href="#wpt-star-full" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				3 Stars			</span>		</i>	</span>		<input		aria-label="Rate this recipe 2 stars"		type="radio"		name="tasty-recipes-rating"		class="tasty-recipes-rating"		id="tasty_recipes_rating_input_6a618690730b0"		value="2">		<span class="tasty-recipes-rating" >		<i class="checked" data-rating="2">			<span class="tasty-recipes-rating-outline" data-tr-clip="0">				<svg class="tasty-recipes-svg" width="18" height="17"><use href="#wpt-star-full" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				2 Stars			</span>		</i>	</span>		<input		aria-label="Rate this recipe 1 star"		type="radio"		name="tasty-recipes-rating"		class="tasty-recipes-rating"		id="tasty_recipes_rating_input_6a61869073100"		value="1">		<span class="tasty-recipes-rating" >		<i class="checked" data-rating="1">			<span class="tasty-recipes-rating-outline" data-tr-clip="0">				<svg class="tasty-recipes-svg" width="18" height="17"><use href="#wpt-star-full" /></svg>			</span>			<span class="tasty-recipes-screen-reader">				1 Star			</span>		</i>	</span></span>		</fieldset>
+		<p class="comment-form-comment"><label for="comment">Comment <span class="required">*</span></label> <textarea id="comment" name="comment" cols="45" rows="8" maxlength="65525" required></textarea></p><p class="comment-form-author"><label for="author">Name <span class="required">*</span></label> <input id="author" name="author" type="text" value="" size="30" maxlength="245" autocomplete="name" required /></p>
+<p class="comment-form-email"><label for="email">Email <span class="required">*</span></label> <input id="email" name="email" type="email" value="" size="30" maxlength="100" aria-describedby="email-notes" autocomplete="email" required /></p>
+<p class="comment-form-url"><label for="url">Website</label> <input id="url" name="url" type="url" value="" size="30" maxlength="200" autocomplete="url" /></p>
+	<p class="comment-form-email-signup">
+		<input id="poy_comment_email_signup" name="poy_comment_email_signup" type="checkbox" value="1"><label for="poy_comment_email_signup">Sign me up for recipes, please!<br>All the food, right to your inbox (and a FREE ecookbook, too!).</label>
+	</p>
+		<p class="form-submit"><input name="submit" type="submit" id="submit" class="submit" value="Post Comment" /> <input type='hidden' name='comment_post_ID' value='23546' id='comment_post_ID' />
+<input type='hidden' name='comment_parent' id='comment_parent' value='0' />
+</p><p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="441d41a887" /></p><p style="display: none !important;" class="akismet-fields-container" data-prefix="ak_"><label>&#916;<textarea name="ak_hp_textarea" cols="45" rows="8" maxlength="100"></textarea></label><input type="hidden" id="ak_js_1" name="ak_js" value="28"/><script>
+document.getElementById( "ak_js_1" ).setAttribute( "value", ( new Date() ).getTime() );
+</script>
+</p></form>	</div><!-- #respond -->
+	
+		
+		<h3 class="font-arvo tracking-widest uppercase text-purple-500 text-kinda-sm not-italic border-b py-2 mt-8 mb-8">792 Comments</h3>
+
+		<ol class="comment-list">
+			
+<li class="comment even thread-even depth-1" id="comment-583849">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/0964431f0b2624862f647d666245804a257e09d7339a8bae3e9de4c3552c9a8a?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/0964431f0b2624862f647d666245804a257e09d7339a8bae3e9de4c3552c9a8a?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Matea"/>
+				<cite class="fn"><a href="http://www.mateamilojkovic.com/" class="url" rel="ugc external nofollow">Matea</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Taco holders are such a great idea! It makes serving them nicely oh-so easy!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T08:09:45-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583849">04/07/15 @ 8:09 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583849" data-commentid="583849" data-postid="23546" data-belowelement="comment-583849" data-respondelement="respond" data-replyto="Reply to Matea" aria-label="Reply to Matea">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-2" id="comment-583979">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/f22c813ce3a669e6c762f1bdc4cb8afb2fb5a73d3e7c37809a8465081d4a972d?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/f22c813ce3a669e6c762f1bdc4cb8afb2fb5a73d3e7c37809a8465081d4a972d?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Laura @ Ryg"/>
+				<cite class="fn"><a href="http://Www.raiseyourgarden.com" class="url" rel="ugc external nofollow">Laura @ Ryg</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>These tacos just look fantastic. Tacos California style. Better than a restaurant with no wait and two cranky kids dropping food on the floor. And you were so right about isle of palms, South Carolina! We are loving it here. Sullivan island really nice too. Charleston amazing. You had so many great suggestions to check out in that post.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T12:05:15-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583979">04/07/15 @ 12:05 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583979" data-commentid="583979" data-postid="23546" data-belowelement="comment-583979" data-respondelement="respond" data-replyto="Reply to Laura @ Ryg" aria-label="Reply to Laura @ Ryg">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment even depth-3" id="comment-824029">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/6b10527cab45ba2904996190eae7428e161f0a33becd178a361f1512034320b3?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/6b10527cab45ba2904996190eae7428e161f0a33becd178a361f1512034320b3?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Christine"/>
+				<cite class="fn">Christine</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Is the amount of lime juice 2 limes as stated above or something else?</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2020-11-02T13:33:51-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-824029">11/02/20 @ 1:33 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-824029" data-commentid="824029" data-postid="23546" data-belowelement="comment-824029" data-respondelement="respond" data-replyto="Reply to Christine" aria-label="Reply to Christine">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-krista-pinch-of-yum odd alt depth-4" id="comment-824265">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/879104f09aaf468fdf98fdf78b54b0f63487cbc303ff8c10e27cdc8380e974e4?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/879104f09aaf468fdf98fdf78b54b0f63487cbc303ff8c10e27cdc8380e974e4?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Krista Teigen"/>
+				<cite class="fn">Krista Teigen</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Yes, juice of 2 limes is correct!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2020-11-04T09:16:26-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-824265">11/04/20 @ 9:16 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-824265" data-commentid="824265" data-postid="23546" data-belowelement="comment-824265" data-respondelement="respond" data-replyto="Reply to Krista Teigen" aria-label="Reply to Krista Teigen">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment even depth-5" id="comment-922404">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/d069112073c20cc3051ff0799ba423bedc928a0b465e470dde98b15dde2265c5?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/d069112073c20cc3051ff0799ba423bedc928a0b465e470dde98b15dde2265c5?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Becky"/>
+				<cite class="fn">Becky</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>These are incredible! I&#8217;ve made these probably 10-15 times since finding this recipe. In fact, having them again tonight! They&#8217;re so good!!!</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2023-01-22T15:29:42-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-922404">01/22/23 @ 3:29 pm</a>
+											</div>
+			<div class="comment-reply">
+							</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-3" id="comment-914314">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/e7ced77a531d2ad11d749dadcebf502c9cd27cb091d849f8d606a85374ca94c1?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/e7ced77a531d2ad11d749dadcebf502c9cd27cb091d849f8d606a85374ca94c1?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Deb"/>
+				<cite class="fn">Deb</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>What kind of oil are you supposed to use? Is vegetable oil fine?</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2022-12-03T17:18:50-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-914314">12/03/22 @ 5:18 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-914314" data-commentid="914314" data-postid="23546" data-belowelement="comment-914314" data-respondelement="respond" data-replyto="Reply to Deb" aria-label="Reply to Deb">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even depth-2" id="comment-584007">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/76f4129650bbd7fbdca3554d714c89bd0c972c7dcf67a33ec5e29c17f26b01f6?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/76f4129650bbd7fbdca3554d714c89bd0c972c7dcf67a33ec5e29c17f26b01f6?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Natali McKee"/>
+				<cite class="fn"><a href="http://www.lessonsfromourlife.com/" class="url" rel="ugc external nofollow">Natali McKee</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Do you think Chicken would go well with them? I am a little freaked out with shrimp.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T23:51:43-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-584007">04/07/15 @ 11:51 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-584007" data-commentid="584007" data-postid="23546" data-belowelement="comment-584007" data-respondelement="respond" data-replyto="Reply to Natali McKee" aria-label="Reply to Natali McKee">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-3" id="comment-585110">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/4f15ce8cdf4ad698b05da8d2edb716973324a9be47fb0f5c844bbdf040965137?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/4f15ce8cdf4ad698b05da8d2edb716973324a9be47fb0f5c844bbdf040965137?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Danni"/>
+				<cite class="fn">Danni</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I would say yes- I made these with shrimp and chicken- absolutely phenomenal and easy. 🙂<br />
+I have to say- these don&#8217;t seem right with anything battered. So good and healthy without it.<br />
+I love this blog. 🙂</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-18T20:33:37-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-585110">04/18/15 @ 8:33 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-585110" data-commentid="585110" data-postid="23546" data-belowelement="comment-585110" data-respondelement="respond" data-replyto="Reply to Danni" aria-label="Reply to Danni">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-kristin-pinch-of-yum even depth-4" id="comment-585131">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Kristin @ Pinch of Yum"/>
+				<cite class="fn"><a href="https://pinchofyum.com/" class="url" rel="ugc">Kristin @ Pinch of Yum</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Thanks Danni! Great suggestions!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-19T14:33:44-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-585131">04/19/15 @ 2:33 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-585131" data-commentid="585131" data-postid="23546" data-belowelement="comment-585131" data-respondelement="respond" data-replyto="Reply to Kristin @ Pinch of Yum" aria-label="Reply to Kristin @ Pinch of Yum">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-4" id="comment-597149">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/8d1351ccaae610f420a1453e4e903ce91202727f901fa7d711b4c352e3d3f99f?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/8d1351ccaae610f420a1453e4e903ce91202727f901fa7d711b4c352e3d3f99f?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Sarah"/>
+				<cite class="fn">Sarah</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>It was so good nice job !</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-10-09T18:38:51-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-597149">10/09/15 @ 6:38 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-597149" data-commentid="597149" data-postid="23546" data-belowelement="comment-597149" data-respondelement="respond" data-replyto="Reply to Sarah" aria-label="Reply to Sarah">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-kristin-pinch-of-yum even depth-5" id="comment-597188">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Kristin @ Pinch of Yum"/>
+				<cite class="fn"><a href="https://pinchofyum.com/" class="url" rel="ugc">Kristin @ Pinch of Yum</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Thanks, Sarah!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-10-10T07:21:38-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-597188">10/10/15 @ 7:21 am</a>
+											</div>
+			<div class="comment-reply">
+							</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-3" id="comment-633023">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/f438f54059e264ac2500c259fb19c5849c74986defaeca4792ca6c91f1235b78?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/f438f54059e264ac2500c259fb19c5849c74986defaeca4792ca6c91f1235b78?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Todd McGuilicutti"/>
+				<cite class="fn"><a href="http://www.toddknowsbest.com" class="url" rel="ugc external nofollow">Todd McGuilicutti</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Why the hell you looking up a shrimp recipe then?</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2016-11-04T13:42:20-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-633023">11/04/16 @ 1:42 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-633023" data-commentid="633023" data-postid="23546" data-belowelement="comment-633023" data-respondelement="respond" data-replyto="Reply to Todd McGuilicutti" aria-label="Reply to Todd McGuilicutti">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment even depth-4" id="comment-670559">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/090a314ea8f1a8995acb9f1ae289495c3d6ed543d19d95dbc93cda42dfabd978?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/090a314ea8f1a8995acb9f1ae289495c3d6ed543d19d95dbc93cda42dfabd978?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="john"/>
+				<cite class="fn">john</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>No evidence he got here by searching specifically for shrimp tacos.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2017-12-01T17:08:37-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-670559">12/01/17 @ 5:08 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-670559" data-commentid="670559" data-postid="23546" data-belowelement="comment-670559" data-respondelement="respond" data-replyto="Reply to john" aria-label="Reply to john">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-4" id="comment-1000396">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/b2df93c278d251cf70b1298c176e2b6f236a593f7765659d0ffe05dae4d8020a?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/b2df93c278d251cf70b1298c176e2b6f236a593f7765659d0ffe05dae4d8020a?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Kathy"/>
+				<cite class="fn">Kathy</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>No need to be rude, dude. Change your attitude. Be more kind.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2025-05-05T17:42:13-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-1000396">05/05/25 @ 5:42 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-1000396" data-commentid="1000396" data-postid="23546" data-belowelement="comment-1000396" data-respondelement="respond" data-replyto="Reply to Kathy" aria-label="Reply to Kathy">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even depth-3" id="comment-749424">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/758a4307452fddbd671a709aa5f3c5dacbb81916453e86a6857efb333e8c1788?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/758a4307452fddbd671a709aa5f3c5dacbb81916453e86a6857efb333e8c1788?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="DNN"/>
+				<cite class="fn"><a href="https://www.drewrynewsnetwork.com/blogs/news/2434-payyourtaxes-don-t-think-you-can-get-away-with-not-paying-taxes-on-your-side-hustle" class="url" rel="ugc external nofollow">DNN</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Chicken blends well with many meals! 🙂</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2019-08-14T16:45:34-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-749424">08/14/19 @ 4:45 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-749424" data-commentid="749424" data-postid="23546" data-belowelement="comment-749424" data-respondelement="respond" data-replyto="Reply to DNN" aria-label="Reply to DNN">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-4" id="comment-810697">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/096cd0c5b484a69f67dca685685595245508124a3d26db518ca8997d63c40998?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/096cd0c5b484a69f67dca685685595245508124a3d26db518ca8997d63c40998?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Jessica Emerson"/>
+				<cite class="fn">Jessica Emerson</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>That sauce- gah!  My dad said the meal was &#8220;restaurant quality.&#8221;  Thank you!</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2020-07-13T18:50:48-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-810697">07/13/20 @ 6:50 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-810697" data-commentid="810697" data-postid="23546" data-belowelement="comment-810697" data-respondelement="respond" data-replyto="Reply to Jessica Emerson" aria-label="Reply to Jessica Emerson">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-eman-pinch-of-yum even depth-5" id="comment-810769">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/22069faec97c7ce3f5c353c84f31a575a2d784216691c6ae247523a03642caca?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/22069faec97c7ce3f5c353c84f31a575a2d784216691c6ae247523a03642caca?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Eman @ Pinch of Yum"/>
+				<cite class="fn"><a href="https://pinchofyum.com/" class="url" rel="ugc">Eman @ Pinch of Yum</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>🤗</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2020-07-14T08:27:12-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-810769">07/14/20 @ 8:27 am</a>
+											</div>
+			<div class="comment-reply">
+							</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-4" id="comment-991522">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/859ccbf8ae4de9df06c8a08e8a106e816c1b4522be28a8aa4316fc93404945c1?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/859ccbf8ae4de9df06c8a08e8a106e816c1b4522be28a8aa4316fc93404945c1?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Ioana Rosenbaum"/>
+				<cite class="fn">Ioana Rosenbaum</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I made it several times now our family loves it.</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2025-03-16T11:02:19-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-991522">03/16/25 @ 11:02 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-991522" data-commentid="991522" data-postid="23546" data-belowelement="comment-991522" data-respondelement="respond" data-replyto="Reply to Ioana Rosenbaum" aria-label="Reply to Ioana Rosenbaum">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even depth-3" id="comment-1048278">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/acd54cef84295f52331214f09cbf0ce40913cd2f8018633564e8a545f7b1b51c?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/acd54cef84295f52331214f09cbf0ce40913cd2f8018633564e8a545f7b1b51c?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Mariane"/>
+				<cite class="fn">Mariane</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>What kind of oil do I use?</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2026-04-20T10:02:40-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-1048278">04/20/26 @ 10:02 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-1048278" data-commentid="1048278" data-postid="23546" data-belowelement="comment-1048278" data-respondelement="respond" data-replyto="Reply to Mariane" aria-label="Reply to Mariane">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-2" id="comment-776949">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/e72b9e83d24440383dd03a1f14b28b623e4637a4bc9a981744dcbfcc796e1692?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/e72b9e83d24440383dd03a1f14b28b623e4637a4bc9a981744dcbfcc796e1692?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Lisa"/>
+				<cite class="fn">Lisa</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Oh, my goodness!  This was a fabulous fast &amp; easy dinner.  The sauce really does make the dish.  Creamy but not at all heavy and a perfect counter to the  shrimp.  I didn&#8217;t have tortillas so I built it on a large bowl of the dressed slaw.  Then I garnished with some tortilla chips.  It&#8217;s a keeper!!</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2020-01-11T19:06:05-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-776949">01/11/20 @ 7:06 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-776949" data-commentid="776949" data-postid="23546" data-belowelement="comment-776949" data-respondelement="respond" data-replyto="Reply to Lisa" aria-label="Reply to Lisa">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment even depth-3" id="comment-1058983">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/9178d14ff2cb854690b02238274516f35a5956481b0cb2164af270a8b54d4dc0?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/9178d14ff2cb854690b02238274516f35a5956481b0cb2164af270a8b54d4dc0?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Sally"/>
+				<cite class="fn">Sally</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Can I use an air fryer to cook shrimp? Have experience doing it this way?</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2026-06-07T07:55:42-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-1058983">06/07/26 @ 7:55 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-1058983" data-commentid="1058983" data-postid="23546" data-belowelement="comment-1058983" data-respondelement="respond" data-replyto="Reply to Sally" aria-label="Reply to Sally">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-2" id="comment-898374">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/2d4e695dae91be2acb793f663c01180807bcaeefb5da0b1a2f707fd42a1d0821?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/2d4e695dae91be2acb793f663c01180807bcaeefb5da0b1a2f707fd42a1d0821?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Lisa Carr"/>
+				<cite class="fn">Lisa Carr</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I was wondering, I do not have  a food processor. Can I use my blender? It&#8217;s ok, of not, I will just wait as I will be getting a blender soon.<br />
+Thank you so much,<br />
+I love all of your delicious recipes!<br />
+Lisa Carr</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2022-04-23T21:54:52-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-898374">04/23/22 @ 9:54 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-898374" data-commentid="898374" data-postid="23546" data-belowelement="comment-898374" data-respondelement="respond" data-replyto="Reply to Lisa Carr" aria-label="Reply to Lisa Carr">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-krista-pinch-of-yum even depth-3" id="comment-898577">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/879104f09aaf468fdf98fdf78b54b0f63487cbc303ff8c10e27cdc8380e974e4?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/879104f09aaf468fdf98fdf78b54b0f63487cbc303ff8c10e27cdc8380e974e4?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Krista @ Pinch of Yum"/>
+				<cite class="fn">Krista @ Pinch of Yum</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Hi Lisa! Yes, a blender should work just fine!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2022-04-25T22:30:27-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-898577">04/25/22 @ 10:30 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-898577" data-commentid="898577" data-postid="23546" data-belowelement="comment-898577" data-respondelement="respond" data-replyto="Reply to Krista @ Pinch of Yum" aria-label="Reply to Krista @ Pinch of Yum">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-odd thread-alt depth-1" id="comment-583850">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/618f79ba96960727ba1e1923f6fbb62ad860ccf5d8c178f1b53fda1b98c7b7ec?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/618f79ba96960727ba1e1923f6fbb62ad860ccf5d8c178f1b53fda1b98c7b7ec?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Michelle @ Modern Acupuncture"/>
+				<cite class="fn"><a href="http://www.modernacu.com/acupuncture-volunteering-project-buena-vista/" class="url" rel="ugc external nofollow">Michelle @ Modern Acupuncture</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Whaaaaaat?! These are beautiful. I&#8217;m so hungry right now, and I will not be able to think of anything else but these tacos until lunch time. And whatever I brought for lunch will pale in comparison, dang it! I love the garlic cilantro lime sauce. I am going to have to try that on everything this spring. So fresh. And the taco holder &#8211; adorable! Who thinks to invent these things??</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T08:29:38-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583850">04/07/15 @ 8:29 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583850" data-commentid="583850" data-postid="23546" data-belowelement="comment-583850" data-respondelement="respond" data-replyto="Reply to Michelle @ Modern Acupuncture" aria-label="Reply to Michelle @ Modern Acupuncture">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment even depth-2" id="comment-935307">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/0a1080a5d89f5ad36768fe942c0975e4b812068d55958f1889d18d80f651e33b?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/0a1080a5d89f5ad36768fe942c0975e4b812068d55958f1889d18d80f651e33b?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="LaVaya"/>
+				<cite class="fn">LaVaya</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Do you need to cook or warm up the corn or flour tortillas before you add the fillings?</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2023-07-20T02:51:03-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-935307">07/20/23 @ 2:51 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-935307" data-commentid="935307" data-postid="23546" data-belowelement="comment-935307" data-respondelement="respond" data-replyto="Reply to LaVaya" aria-label="Reply to LaVaya">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-eman-pinch-of-yum odd alt depth-3" id="comment-935385">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/22069faec97c7ce3f5c353c84f31a575a2d784216691c6ae247523a03642caca?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/22069faec97c7ce3f5c353c84f31a575a2d784216691c6ae247523a03642caca?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Eman @ Pinch of Yum"/>
+				<cite class="fn"><a href="https://pinchofyum.com/" class="url" rel="ugc">Eman @ Pinch of Yum</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>You could quickly fry them up or char them if you wanted before filling them.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2023-07-21T09:22:05-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-935385">07/21/23 @ 9:22 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-935385" data-commentid="935385" data-postid="23546" data-belowelement="comment-935385" data-respondelement="respond" data-replyto="Reply to Eman @ Pinch of Yum" aria-label="Reply to Eman @ Pinch of Yum">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even thread-even depth-1" id="comment-583852">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/f93bb10bfb672ca743bc98ff2f92fb4dab527f4e5e286dbb0c568c6c177bf181?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/f93bb10bfb672ca743bc98ff2f92fb4dab527f4e5e286dbb0c568c6c177bf181?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Bonnie C"/>
+				<cite class="fn"><a href="http://experiment801.com" class="url" rel="ugc external nofollow">Bonnie C</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>#1 I saw TACOS in the post title and clicked so fast my computer flinched. I recently declared Tuesdays &#8220;Taco Tuesday&#8221; on my menu planning software, so this will come in extremely handy. 😀</p>
+<p>#2 I saw the taco holder in the first pic and was all, &#8220;omg shut up and take my money!!&#8221; and was planning to race through to the comments to beg you for the source and you totes beat me to the punch. lol</p>
+<p>#3 Can&#8217;t wait to try these. 😀</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T08:40:16-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583852">04/07/15 @ 8:40 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583852" data-commentid="583852" data-postid="23546" data-belowelement="comment-583852" data-respondelement="respond" data-replyto="Reply to Bonnie C" aria-label="Reply to Bonnie C">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-lindsay bypostauthor odd alt depth-2" id="comment-583859">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Lindsay"/>
+				<cite class="fn"><a href="https://pinchofyum.com" class="url" rel="ugc">Lindsay</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>haha &#8211; that&#8217;s so funny! enjoy the taco holder &#8211; it&#8217;s so cool! I will never go back to flat-on-the-plate tacos.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T09:12:13-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583859">04/07/15 @ 9:12 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583859" data-commentid="583859" data-postid="23546" data-belowelement="comment-583859" data-respondelement="respond" data-replyto="Reply to Lindsay" aria-label="Reply to Lindsay">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment even depth-3" id="comment-593779">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/7a5ee2cb9cd5172f5e3566ec962d82dc9991eb76be21160d1dff6599baac8ddd?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/7a5ee2cb9cd5172f5e3566ec962d82dc9991eb76be21160d1dff6599baac8ddd?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Terry"/>
+				<cite class="fn">Terry</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Looking at this recipe and planning on trying it out tonight. Just wanted to point out a little typo. For shrimp, I think you mean heads removed. LOL! I would also recommend thoroughly rinsing them 3-4 times to remove the iodine. New to your blog. Love your recipes and blogs. And can&#8217;t wait to try out more of your recipes!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-08-15T17:32:55-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-593779">08/15/15 @ 5:32 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-593779" data-commentid="593779" data-postid="23546" data-belowelement="comment-593779" data-respondelement="respond" data-replyto="Reply to Terry" aria-label="Reply to Terry">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-kristin-pinch-of-yum odd alt depth-4" id="comment-593802">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Kristin @ Pinch of Yum"/>
+				<cite class="fn"><a href="https://pinchofyum.com/" class="url" rel="ugc">Kristin @ Pinch of Yum</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Thanks for the tips, Terry!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-08-16T14:00:39-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-593802">08/16/15 @ 2:00 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-593802" data-commentid="593802" data-postid="23546" data-belowelement="comment-593802" data-respondelement="respond" data-replyto="Reply to Kristin @ Pinch of Yum" aria-label="Reply to Kristin @ Pinch of Yum">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment even depth-5" id="comment-593815">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/7a5ee2cb9cd5172f5e3566ec962d82dc9991eb76be21160d1dff6599baac8ddd?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/7a5ee2cb9cd5172f5e3566ec962d82dc9991eb76be21160d1dff6599baac8ddd?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Terry"/>
+				<cite class="fn">Terry</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>OMG! Made these last night. My husband, son &amp; I loved them. Thanks again!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-08-16T19:27:22-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-593815">08/16/15 @ 7:27 pm</a>
+											</div>
+			<div class="comment-reply">
+							</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment byuser comment-author-kristin-pinch-of-yum odd alt depth-5" id="comment-593993">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Kristin @ Pinch of Yum"/>
+				<cite class="fn"><a href="https://pinchofyum.com/" class="url" rel="ugc">Kristin @ Pinch of Yum</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Awesome, Terry!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-08-18T20:48:00-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-593993">08/18/15 @ 8:48 pm</a>
+											</div>
+			<div class="comment-reply">
+							</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even depth-5" id="comment-626529">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/2bc7491166448504e06255d025e0143ab512d7c74950d7079c542e537cb3b6c3?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/2bc7491166448504e06255d025e0143ab512d7c74950d7079c542e537cb3b6c3?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Missy"/>
+				<cite class="fn">Missy</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I hope it&#8217;s ok to pipe in&#8230;.not that it is a big deal or anything&#8230; but I saw this comment when scrolling through, and if I had to guess, I would assume that the directions actually did mean to say to take the tail off the shrimp, not the head, am I correct?? I only say this because I learned an interesting fact a few years ago about why the the vast majority of shrimp sold (and purchased) in stores are shrimps without the heads.  Apparently, if the head is kept on the shrimp for even a couple of hours after it&#8217;s dead, it will begin to release strong enzymes into the body of the shrimp, which then break down the shrimp flesh and make the shrimp super mushy and yucky, and no one wants that!!! I know this is super irrelevant and unnecessary to respond to a comment a year later, but I figured I would share my knowledge to anyone who wanted to listen lol. Anyways&#8230;.. thanks for the amazing recipe!!! I was actually also curious where you went in CA that you got these tacos originally, as I live here in So Cal, and just wanted to see if maybe there is a new place I have to go check out for a date night or something =) Thank&#8217;s again for the great recipe, can&#8217;t wait to check out more on here =)</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2016-08-03T07:54:11-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-626529">08/03/16 @ 7:54 am</a>
+											</div>
+			<div class="comment-reply">
+							</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-4" id="comment-652827">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/2589c28c0abcf5f0d7e0804dfcc3b0fdad59a6d6f2e052fe14d04a443e6f42ab?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/2589c28c0abcf5f0d7e0804dfcc3b0fdad59a6d6f2e052fe14d04a443e6f42ab?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Marion"/>
+				<cite class="fn">Marion</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Terry, I think she did mean remove the tails. Some shrimp recipes, mostly fried, specify to leave the tails on. Also, some food photographers prefer to picture the shrimp tails on, even the recipe obviously call for their removal, but doesn&#8217;t specify. And, Missy, I&#8217;d do some research about the dangers of leaving the heads on. My experience says otherwise.</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2017-05-05T11:18:21-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-652827">05/05/17 @ 11:18 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-652827" data-commentid="652827" data-postid="23546" data-belowelement="comment-652827" data-respondelement="respond" data-replyto="Reply to Marion" aria-label="Reply to Marion">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even depth-3" id="comment-739994">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/cee2728d510c4ef75adb7128a8040c4a4925bc55cdb75236812aa4a42b9bbfdf?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/cee2728d510c4ef75adb7128a8040c4a4925bc55cdb75236812aa4a42b9bbfdf?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Melissa"/>
+				<cite class="fn">Melissa</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I seriously thought I had every kitchen gadget I could possibly need, and you have to go and show me taco holders! 😂❤</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2019-05-26T20:15:43-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-739994">05/26/19 @ 8:15 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-739994" data-commentid="739994" data-postid="23546" data-belowelement="comment-739994" data-respondelement="respond" data-replyto="Reply to Melissa" aria-label="Reply to Melissa">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-4" id="comment-750088">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/21129d6506fb64872e4908676c1a5d6a81a90cc18114cdccc2e33fd85de38041?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/21129d6506fb64872e4908676c1a5d6a81a90cc18114cdccc2e33fd85de38041?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Ana"/>
+				<cite class="fn">Ana</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Amazing tacos<br />
+Thank you!</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2019-08-21T23:51:48-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-750088">08/21/19 @ 11:51 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-750088" data-commentid="750088" data-postid="23546" data-belowelement="comment-750088" data-respondelement="respond" data-replyto="Reply to Ana" aria-label="Reply to Ana">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even depth-2" id="comment-585433">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/5ab38bcf297d351d20e157fee48cea34c575258c7048b62a44a7c37fc228595a?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/5ab38bcf297d351d20e157fee48cea34c575258c7048b62a44a7c37fc228595a?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Caryn"/>
+				<cite class="fn">Caryn</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>what meal planning software do you use?</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-23T11:39:29-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-585433">04/23/15 @ 11:39 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-585433" data-commentid="585433" data-postid="23546" data-belowelement="comment-585433" data-respondelement="respond" data-replyto="Reply to Caryn" aria-label="Reply to Caryn">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-3" id="comment-806305">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/6f123e051a27ef2bc763c5c3c0616fec0b1b5e9a4efb1b60a0d4ca56ca3b09a2?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/6f123e051a27ef2bc763c5c3c0616fec0b1b5e9a4efb1b60a0d4ca56ca3b09a2?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Doris Liebrecht"/>
+				<cite class="fn">Doris Liebrecht</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Yeah what mysterious meal planning software are you referring to? Inquiring mind have to know!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2020-06-06T15:00:57-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-806305">06/06/20 @ 3:00 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-806305" data-commentid="806305" data-postid="23546" data-belowelement="comment-806305" data-respondelement="respond" data-replyto="Reply to Doris Liebrecht" aria-label="Reply to Doris Liebrecht">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even thread-odd thread-alt depth-1" id="comment-583853">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/6d691db5c4931dfae38f3aa7a6fb93d9657afc3168b5dfa89407f0db6c1b5366?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/6d691db5c4931dfae38f3aa7a6fb93d9657afc3168b5dfa89407f0db6c1b5366?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Shobelyn Dayrit"/>
+				<cite class="fn"><a href="http://theskinnypot.com" class="url" rel="ugc external nofollow">Shobelyn Dayrit</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Tacos are my favorite, and this certainly looks  like a delicious and filling.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T08:40:24-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583853">04/07/15 @ 8:40 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583853" data-commentid="583853" data-postid="23546" data-belowelement="comment-583853" data-respondelement="respond" data-replyto="Reply to Shobelyn Dayrit" aria-label="Reply to Shobelyn Dayrit">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-2" id="comment-797849">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/0ce9934609f6191ed528acd6e15e86b31c6fc6ff0566cce348b55403356c0c42?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/0ce9934609f6191ed528acd6e15e86b31c6fc6ff0566cce348b55403356c0c42?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Molly"/>
+				<cite class="fn">Molly</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I don’t have green onion on hand&#8230;. I have red and yellow onions? Any suggestions?</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2020-04-21T17:46:43-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-797849">04/21/20 @ 5:46 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-797849" data-commentid="797849" data-postid="23546" data-belowelement="comment-797849" data-respondelement="respond" data-replyto="Reply to Molly" aria-label="Reply to Molly">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-eman-pinch-of-yum even depth-3" id="comment-798031">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/22069faec97c7ce3f5c353c84f31a575a2d784216691c6ae247523a03642caca?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/22069faec97c7ce3f5c353c84f31a575a2d784216691c6ae247523a03642caca?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Eman @ Pinch of Yum"/>
+				<cite class="fn"><a href="https://pinchofyum.com/" class="url" rel="ugc">Eman @ Pinch of Yum</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>You could use a little bit of red onion.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2020-04-22T09:18:32-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-798031">04/22/20 @ 9:18 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-798031" data-commentid="798031" data-postid="23546" data-belowelement="comment-798031" data-respondelement="respond" data-replyto="Reply to Eman @ Pinch of Yum" aria-label="Reply to Eman @ Pinch of Yum">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-even depth-1" id="comment-583855">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/fc7d7888974f730bbe154fa143681f7f6fc9d7ba7a1f3c88303bd81c37daa370?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/fc7d7888974f730bbe154fa143681f7f6fc9d7ba7a1f3c88303bd81c37daa370?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Ali @ Whisk and Repeat"/>
+				<cite class="fn"><a href="http://www.whiskandrepeat.com" class="url" rel="ugc external nofollow">Ali @ Whisk and Repeat</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Shrimp tacos are my love language! These look so darn good&#8230; tacos + shrimp + spicy = can&#8217;t go wrong.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T08:43:34-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583855">04/07/15 @ 8:43 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583855" data-commentid="583855" data-postid="23546" data-belowelement="comment-583855" data-respondelement="respond" data-replyto="Reply to Ali @ Whisk and Repeat" aria-label="Reply to Ali @ Whisk and Repeat">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even thread-odd thread-alt depth-1" id="comment-583857">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/b8e4b9cb451a49d9846951e54829589f97519a9391f5cfe5bd91ed2c822d456a?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/b8e4b9cb451a49d9846951e54829589f97519a9391f5cfe5bd91ed2c822d456a?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="MARIA"/>
+				<cite class="fn">MARIA</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>How much lime juice do you add to the sauce?  Can&#8217;t wait to try these, I really love your recipes!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T09:00:34-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583857">04/07/15 @ 9:00 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583857" data-commentid="583857" data-postid="23546" data-belowelement="comment-583857" data-respondelement="respond" data-replyto="Reply to MARIA" aria-label="Reply to MARIA">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-lindsay bypostauthor odd alt depth-2" id="comment-583858">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Lindsay"/>
+				<cite class="fn"><a href="https://pinchofyum.com" class="url" rel="ugc">Lindsay</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Juice of two limes! thanks for the catch Maria!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T09:11:29-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583858">04/07/15 @ 9:11 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583858" data-commentid="583858" data-postid="23546" data-belowelement="comment-583858" data-respondelement="respond" data-replyto="Reply to Lindsay" aria-label="Reply to Lindsay">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment even depth-3" id="comment-663943">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/4733430648778d56287f12c3a8ec8b3c7cf90149fd478eb03530ca99c1f8d032?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/4733430648778d56287f12c3a8ec8b3c7cf90149fd478eb03530ca99c1f8d032?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="J"/>
+				<cite class="fn">J</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I hate two lines, please specify in tsp. Some limes have a little juice and some have a lot.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2017-10-09T12:06:35-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-663943">10/09/17 @ 12:06 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-663943" data-commentid="663943" data-postid="23546" data-belowelement="comment-663943" data-respondelement="respond" data-replyto="Reply to J" aria-label="Reply to J">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-4" id="comment-677308">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/23c550f9eb8f9a9bd235ced4e931f75116d688354bfba82fc6c103647d8663c0?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/23c550f9eb8f9a9bd235ced4e931f75116d688354bfba82fc6c103647d8663c0?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Verona"/>
+				<cite class="fn">Verona</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I would do two limes and then if you taste it and want more, add more. Lime preferences are very individualistic.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2018-01-04T16:47:12-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-677308">01/04/18 @ 4:47 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-677308" data-commentid="677308" data-postid="23546" data-belowelement="comment-677308" data-respondelement="respond" data-replyto="Reply to Verona" aria-label="Reply to Verona">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even depth-3" id="comment-748848">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/758a4307452fddbd671a709aa5f3c5dacbb81916453e86a6857efb333e8c1788?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/758a4307452fddbd671a709aa5f3c5dacbb81916453e86a6857efb333e8c1788?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="DNN"/>
+				<cite class="fn"><a href="https://www.drewrynewsnetwork.com/forum/health/diets-healthy-eating/2405-eatingright-5-ways-to-eathealthy-without-spending-too-much-money" class="url" rel="ugc external nofollow">DNN</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>two limes sounds pretty good to me, Lindsay. 🙂</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2019-08-07T09:42:05-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-748848">08/07/19 @ 9:42 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-748848" data-commentid="748848" data-postid="23546" data-belowelement="comment-748848" data-respondelement="respond" data-replyto="Reply to DNN" aria-label="Reply to DNN">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-3" id="comment-923209">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/69cca4310b5c799332353357082103ff4255b60d24bffb87d251cea77cce6fd8?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/69cca4310b5c799332353357082103ff4255b60d24bffb87d251cea77cce6fd8?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Michelle"/>
+				<cite class="fn">Michelle</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Would that be 2 small limes or the larger ones?</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2023-02-01T10:11:43-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-923209">02/01/23 @ 10:11 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-923209" data-commentid="923209" data-postid="23546" data-belowelement="comment-923209" data-respondelement="respond" data-replyto="Reply to Michelle" aria-label="Reply to Michelle">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-eman-pinch-of-yum even depth-4" id="comment-923210">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/22069faec97c7ce3f5c353c84f31a575a2d784216691c6ae247523a03642caca?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/22069faec97c7ce3f5c353c84f31a575a2d784216691c6ae247523a03642caca?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Eman @ Pinch of Yum"/>
+				<cite class="fn"><a href="https://pinchofyum.com/" class="url" rel="ugc">Eman @ Pinch of Yum</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>2 medium-size limes here! 😊</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2023-02-01T10:37:47-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-923210">02/01/23 @ 10:37 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-923210" data-commentid="923210" data-postid="23546" data-belowelement="comment-923210" data-respondelement="respond" data-replyto="Reply to Eman @ Pinch of Yum" aria-label="Reply to Eman @ Pinch of Yum">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-even depth-1" id="comment-583867">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/240da0b047e092f4ad2c29f8f0d08f589c49e92de6319fcb81b85a2a79212feb?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/240da0b047e092f4ad2c29f8f0d08f589c49e92de6319fcb81b85a2a79212feb?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Erin @ Erin&#039;s Inside Job"/>
+				<cite class="fn"><a href="https://erinsinsidejob.com/" class="url" rel="ugc external nofollow">Erin @ Erin's Inside Job</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>These look awesome! Once the weather gets a little warmer here I may have to break these out. Thanks for sharing!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T09:17:13-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583867">04/07/15 @ 9:17 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583867" data-commentid="583867" data-postid="23546" data-belowelement="comment-583867" data-respondelement="respond" data-replyto="Reply to Erin @ Erin&#039;s Inside Job" aria-label="Reply to Erin @ Erin&#039;s Inside Job">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even thread-odd thread-alt depth-1" id="comment-583874">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/491a151e340853bef1295a50202936d665325b087089196e29484013db258eac?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/491a151e340853bef1295a50202936d665325b087089196e29484013db258eac?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="The Prestigious School"/>
+				<cite class="fn"><a href="http://theprestigiousschool.com" class="url" rel="ugc external nofollow">The Prestigious School</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Shrimp Tacos!  Just in time for Taco Tuesday at my house.  These look like a great way to refresh our palettes after all that Easter ham&#8230;</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T09:19:41-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583874">04/07/15 @ 9:19 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583874" data-commentid="583874" data-postid="23546" data-belowelement="comment-583874" data-respondelement="respond" data-replyto="Reply to The Prestigious School" aria-label="Reply to The Prestigious School">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-2" id="comment-749346">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/758a4307452fddbd671a709aa5f3c5dacbb81916453e86a6857efb333e8c1788?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/758a4307452fddbd671a709aa5f3c5dacbb81916453e86a6857efb333e8c1788?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="DNN"/>
+				<cite class="fn"><a href="https://www.drewrynewsnetwork.com/forum/affiliate-marketing/content-marketing-seo/2431-contentmarketing-3-surefire-ways-to-build-free-traffic-and-improve-seo" class="url" rel="ugc external nofollow">DNN</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>And I just ate a Steak quesadilla this morning with 2 sour cream packets from WaWa! 😛</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2019-08-13T07:45:33-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-749346">08/13/19 @ 7:45 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-749346" data-commentid="749346" data-postid="23546" data-belowelement="comment-749346" data-respondelement="respond" data-replyto="Reply to DNN" aria-label="Reply to DNN">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even depth-2" id="comment-891183">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/87c95fa747df9176c3f4bd5b9739ebf4483620aa33fde5741a31c202e9304d2b?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/87c95fa747df9176c3f4bd5b9739ebf4483620aa33fde5741a31c202e9304d2b?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Shannon"/>
+				<cite class="fn">Shannon</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Amazing! Loved everything about this recipe &#8211; wouldn’t change a thing. I did substitute feta because the recommended cheese is hard to find here. </p>
+<p>That sauce is incredible! Will definitely be making these again soon! Thanks for another amazing recipe.</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2022-01-28T05:11:54-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-891183">01/28/22 @ 5:11 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-891183" data-commentid="891183" data-postid="23546" data-belowelement="comment-891183" data-respondelement="respond" data-replyto="Reply to Shannon" aria-label="Reply to Shannon">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt depth-2" id="comment-920743">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/7e016dcdf609db8293255cd3a6aa9bcab4c632e182cdc65f0df950e875394b11?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/7e016dcdf609db8293255cd3a6aa9bcab4c632e182cdc65f0df950e875394b11?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Devi hayutin"/>
+				<cite class="fn">Devi hayutin</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>So good lol</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2022-12-29T10:27:45-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-920743">12/29/22 @ 10:27 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-920743" data-commentid="920743" data-postid="23546" data-belowelement="comment-920743" data-respondelement="respond" data-replyto="Reply to Devi hayutin" aria-label="Reply to Devi hayutin">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even thread-even depth-1" id="comment-583898">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/9eb1bfab40c273956faa37579b81cbe21cbe86c4f22e268768001119a5c6159d?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/9eb1bfab40c273956faa37579b81cbe21cbe86c4f22e268768001119a5c6159d?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Ashley Olson"/>
+				<cite class="fn">Ashley Olson</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Lindsay, these look so amazing! I will be making them on the double! Quick question, we are planning a trip to San Diego area to visit friends and I would LOVE to try the taco that inspired this! Care to share where you had it at? Thanks for sharing!!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T09:31:14-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583898">04/07/15 @ 9:31 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583898" data-commentid="583898" data-postid="23546" data-belowelement="comment-583898" data-respondelement="respond" data-replyto="Reply to Ashley Olson" aria-label="Reply to Ashley Olson">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-lindsay bypostauthor odd alt depth-2" id="comment-584044">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Lindsay"/>
+				<cite class="fn"><a href="https://pinchofyum.com" class="url" rel="ugc">Lindsay</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Yes! We were actually in Long Beach at Simmzy&#8217;s and the shrimp tacos I loved so much were the nightly special. 🙂</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-08T15:36:59-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-584044">04/08/15 @ 3:36 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-584044" data-commentid="584044" data-postid="23546" data-belowelement="comment-584044" data-respondelement="respond" data-replyto="Reply to Lindsay" aria-label="Reply to Lindsay">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even depth-2" id="comment-592754">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/9fd277c936e0d95f61e2f1c4107ce83e9291364bf787e9c99bcf436ad2c5cd3c?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/9fd277c936e0d95f61e2f1c4107ce83e9291364bf787e9c99bcf436ad2c5cd3c?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Anne"/>
+				<cite class="fn">Anne</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>We found this on a trip to San Diego.  &#8220;Blue Water&#8221;, we enjoyed everything we had there.  It is small, casual, but the seafood is fresh and good.  We ended up going there several times on our 4 day stay in the area.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-07-26T17:11:22-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-592754">07/26/15 @ 5:11 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-592754" data-commentid="592754" data-postid="23546" data-belowelement="comment-592754" data-respondelement="respond" data-replyto="Reply to Anne" aria-label="Reply to Anne">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-odd thread-alt depth-1" id="comment-583932">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/37d8f34c0ad1fdc103a5c673f893db253f6c975842e8cc3e8e29b06eaa0cd179?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/37d8f34c0ad1fdc103a5c673f893db253f6c975842e8cc3e8e29b06eaa0cd179?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Brittany"/>
+				<cite class="fn">Brittany</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Tacos and beer are the perfect combination in my book! Could eat everyday</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T09:50:28-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583932">04/07/15 @ 9:50 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583932" data-commentid="583932" data-postid="23546" data-belowelement="comment-583932" data-respondelement="respond" data-replyto="Reply to Brittany" aria-label="Reply to Brittany">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even thread-even depth-1" id="comment-583934">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/7e8375121fe1240713c4ef51d0b347e3f176319494ee5c7975c98eb91566dcc5?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/7e8375121fe1240713c4ef51d0b347e3f176319494ee5c7975c98eb91566dcc5?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Heather @ HeatherOMade"/>
+				<cite class="fn"><a href="http://heatheromade.blogspot.com" class="url" rel="ugc external nofollow">Heather @ HeatherOMade</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>you had me at taco! i need these taco holders!!<br />
+<a target="_blank" href="http://heatheromade.blogspot.com/search?q=+tacos" rel="nofollow ugc">http://heatheromade.blogspot.com/search?q=+tacos</a></p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T09:50:59-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583934">04/07/15 @ 9:50 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583934" data-commentid="583934" data-postid="23546" data-belowelement="comment-583934" data-respondelement="respond" data-replyto="Reply to Heather @ HeatherOMade" aria-label="Reply to Heather @ HeatherOMade">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-2" id="comment-583971">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/37597de13b78dddacb844be14b50aca7a5dc266c6f6104b600bb5a4eb3a04313?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/37597de13b78dddacb844be14b50aca7a5dc266c6f6104b600bb5a4eb3a04313?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="john godino"/>
+				<cite class="fn">john godino</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Heather, try a Web search before you buy the taco holders, there are many less expensive options available.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T11:07:11-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583971">04/07/15 @ 11:07 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583971" data-commentid="583971" data-postid="23546" data-belowelement="comment-583971" data-respondelement="respond" data-replyto="Reply to john godino" aria-label="Reply to john godino">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even thread-odd thread-alt depth-1" id="comment-583944">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/73c475038d939509b1cfd1132029748fa806fe02a237d367164924f05d32c57e?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/73c475038d939509b1cfd1132029748fa806fe02a237d367164924f05d32c57e?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Karen @ On the Banks of Salt Creek"/>
+				<cite class="fn"><a href="http://www.onthebanksofsaltcreek.com" class="url" rel="ugc external nofollow">Karen @ On the Banks of Salt Creek</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>TACOS! Mmmmm me want TACOS!<br />
+We already make six different version of tacos (we are a taco family) but this sounds like it could jump to the top of the favorite list.<br />
+Great recipe.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T10:01:41-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583944">04/07/15 @ 10:01 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583944" data-commentid="583944" data-postid="23546" data-belowelement="comment-583944" data-respondelement="respond" data-replyto="Reply to Karen @ On the Banks of Salt Creek" aria-label="Reply to Karen @ On the Banks of Salt Creek">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-even depth-1" id="comment-583958">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/6acf6917dee8b4b56bbc722222f0be79e90ef841589b2cfea9fcc1d689a853ea?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/6acf6917dee8b4b56bbc722222f0be79e90ef841589b2cfea9fcc1d689a853ea?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="S Lauren | Modern Granola"/>
+				<cite class="fn"><a href="http://www.moderngranola.com/" class="url" rel="ugc external nofollow">S Lauren | Modern Granola</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Yum! This looks sooo good! I&#8217;ve been on a taco kick for a while now, so I&#8217;ll have to give this recipe a try! Thanks!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T10:15:07-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583958">04/07/15 @ 10:15 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583958" data-commentid="583958" data-postid="23546" data-belowelement="comment-583958" data-respondelement="respond" data-replyto="Reply to S Lauren | Modern Granola" aria-label="Reply to S Lauren | Modern Granola">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even thread-odd thread-alt depth-1" id="comment-583967">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/eb15d15efbd74494091e64ffdd7fd95eb19574653d07ff2335309b416b23710d?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/eb15d15efbd74494091e64ffdd7fd95eb19574653d07ff2335309b416b23710d?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Amy @ Accidental Happy Baker"/>
+				<cite class="fn"><a href="https://www.accidentalhappybaker.com/" class="url" rel="ugc external nofollow">Amy @ Accidental Happy Baker</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>YES! So glad I literally stumbled across this this morning. I have shrimp in my fridge I need to use up. I&#8217;ve never had shrimp tacos before, living in the boonies of the midwest you kind of hesitate to try shrimp tacos at the local Mexican eateries, if you know what I mean.  But it is on my food bucket list! So now I can try them risk free. haha.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T10:30:27-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583967">04/07/15 @ 10:30 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583967" data-commentid="583967" data-postid="23546" data-belowelement="comment-583967" data-respondelement="respond" data-replyto="Reply to Amy @ Accidental Happy Baker" aria-label="Reply to Amy @ Accidental Happy Baker">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-even depth-1" id="comment-583968">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/98365270fe9e74594121da2ea443db55d41f77b7b177d62c2e8a25cff1b791cf?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/98365270fe9e74594121da2ea443db55d41f77b7b177d62c2e8a25cff1b791cf?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Holly"/>
+				<cite class="fn"><a href="http://broccolitrees.com/" class="url" rel="ugc external nofollow">Holly</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>OK this needs to be my dinner asap. Looks beautiful and delicious!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T10:52:11-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583968">04/07/15 @ 10:52 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583968" data-commentid="583968" data-postid="23546" data-belowelement="comment-583968" data-respondelement="respond" data-replyto="Reply to Holly" aria-label="Reply to Holly">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even thread-odd thread-alt depth-1" id="comment-583969">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/5c1cf5a61a328928745190757e2c9952e1c4570df64620339840c5ddc0b2b9ef?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/5c1cf5a61a328928745190757e2c9952e1c4570df64620339840c5ddc0b2b9ef?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Lindsay@BluegrassBites"/>
+				<cite class="fn"><a href="http://bluegrassbites.com/" class="url" rel="ugc external nofollow">Lindsay@BluegrassBites</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>These totally scream warm weather and patio dining! Can&#8217;t wait to give them a go!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T10:52:55-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583969">04/07/15 @ 10:52 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583969" data-commentid="583969" data-postid="23546" data-belowelement="comment-583969" data-respondelement="respond" data-replyto="Reply to Lindsay@BluegrassBites" aria-label="Reply to Lindsay@BluegrassBites">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-even depth-1" id="comment-583970">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/37597de13b78dddacb844be14b50aca7a5dc266c6f6104b600bb5a4eb3a04313?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/37597de13b78dddacb844be14b50aca7a5dc266c6f6104b600bb5a4eb3a04313?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="john godino"/>
+				<cite class="fn">john godino</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>This recipe looks AMZING will try pronto.</p>
+<p>I made a similar green sauce recently based on something I tried in my favorite Taqueria: next in food processor the following &#8211; 1 bunch cilantro, 1/2 onion, jalapeno(s), 1 avocado, juice from 2 limes, water dribbled in until the consistency looks right.</p>
+<p>The taco holders are a clever design, but wowzer, $22 for ONE!?<br />
+And if you wanted to serve four people tacos, you probably want one for each person, so that&#8217;s almost $100 for some little gizmos that keep your tacos upright?</p>
+<p>One would think most people reading this blog have better things to do with the hundred bucks.</p>
+<p>Be a smart shopper, and do a web search of  . You will find many examples of these for a LOT le$$. My first results showed a stainless steel one from a restaurant supply store under four dollars.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T11:05:55-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583970">04/07/15 @ 11:05 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583970" data-commentid="583970" data-postid="23546" data-belowelement="comment-583970" data-respondelement="respond" data-replyto="Reply to john godino" aria-label="Reply to john godino">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-lindsay bypostauthor even depth-2" id="comment-584045">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Lindsay"/>
+				<cite class="fn"><a href="https://pinchofyum.com" class="url" rel="ugc">Lindsay</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Hi John! Thanks for the feedback &#8211; the price DEFINITELY went up since I first put the link in. I&#8217;m guessing the company adjusts their price based on supply and demand. Really frustrating as I would not recommend anyone buy a taco holder for $22. </p>
+<p>I&#8217;ve updated the link to direct to a similar but more affordable option (from a different seller) from Amazon. The new ones, at the time of updating this, are about $7 which is what I paid for mine. </p>
+<p>Thanks for the catch!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-08T15:39:07-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-584045">04/08/15 @ 3:39 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-584045" data-commentid="584045" data-postid="23546" data-belowelement="comment-584045" data-respondelement="respond" data-replyto="Reply to Lindsay" aria-label="Reply to Lindsay">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-3" id="comment-948985">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/ff284bae4617545a675b984dfe7bcab9e38150db2798f623ef520ca8be97f45e?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/ff284bae4617545a675b984dfe7bcab9e38150db2798f623ef520ca8be97f45e?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Susan"/>
+				<cite class="fn">Susan</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Where can I find the link for the taco holders?</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2024-01-07T10:22:18-06:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-948985">01/07/24 @ 10:22 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-948985" data-commentid="948985" data-postid="23546" data-belowelement="comment-948985" data-respondelement="respond" data-replyto="Reply to Susan" aria-label="Reply to Susan">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even depth-2" id="comment-590542">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/a9e9153b499154c62a01192fd9f2a6d2d23df10f34232306861d033bddb78e3e?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/a9e9153b499154c62a01192fd9f2a6d2d23df10f34232306861d033bddb78e3e?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Sharon"/>
+				<cite class="fn">Sharon</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Turn a muffin baking pan upside down its a perfect taco holder</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-07-02T21:56:21-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-590542">07/02/15 @ 9:56 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-590542" data-commentid="590542" data-postid="23546" data-belowelement="comment-590542" data-respondelement="respond" data-replyto="Reply to Sharon" aria-label="Reply to Sharon">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-kristin-pinch-of-yum odd alt depth-3" id="comment-590581">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/bd466a207c4e64f393ce7b82e442bc41fb798d8b62a0203fc6cf13207dd474ad?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Kristin @ Pinch of Yum"/>
+				<cite class="fn"><a href="https://pinchofyum.com/" class="url" rel="ugc">Kristin @ Pinch of Yum</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>What a creative idea, Sharon! Thanks!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-07-03T11:01:25-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-590581">07/03/15 @ 11:01 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-590581" data-commentid="590581" data-postid="23546" data-belowelement="comment-590581" data-respondelement="respond" data-replyto="Reply to Kristin @ Pinch of Yum" aria-label="Reply to Kristin @ Pinch of Yum">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even depth-3" id="comment-855208">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/6f6879912f553b8215091958ffdb49a6368d7781b369616a1ab1852fd6830b73?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/6f6879912f553b8215091958ffdb49a6368d7781b369616a1ab1852fd6830b73?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Michaella Clark"/>
+				<cite class="fn">Michaella Clark</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Hi, I am wondering with the leftover cilantro sauce, or if you made double, could you freeze that?</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="5"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2021-06-30T11:28:49-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-855208">06/30/21 @ 11:28 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-855208" data-commentid="855208" data-postid="23546" data-belowelement="comment-855208" data-respondelement="respond" data-replyto="Reply to Michaella Clark" aria-label="Reply to Michaella Clark">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-krista-pinch-of-yum odd alt depth-4" id="comment-855409">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/879104f09aaf468fdf98fdf78b54b0f63487cbc303ff8c10e27cdc8380e974e4?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/879104f09aaf468fdf98fdf78b54b0f63487cbc303ff8c10e27cdc8380e974e4?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Krista @ Pinch of Yum"/>
+				<cite class="fn">Krista @ Pinch of Yum</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>We haven&#8217;t tried freezing the sauce before. I&#8217;m not sure how the texture would be after it defrosts. It may be okay if you give it a good stir!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2021-07-02T15:13:44-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-855409">07/02/21 @ 3:13 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-855409" data-commentid="855409" data-postid="23546" data-belowelement="comment-855409" data-respondelement="respond" data-replyto="Reply to Krista @ Pinch of Yum" aria-label="Reply to Krista @ Pinch of Yum">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even thread-odd thread-alt depth-1" id="comment-583974">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/d1e78b063aae9d043e33326e1b615b10603824a0c5c2b1cd4b236e2fa1d2665b?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/d1e78b063aae9d043e33326e1b615b10603824a0c5c2b1cd4b236e2fa1d2665b?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Whitney @ Sweet Cayenne"/>
+				<cite class="fn"><a href="https://sweetcayenne.com/" class="url" rel="ugc external nofollow">Whitney @ Sweet Cayenne</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I tried your beer-battered fish tacos a few weeks ago and WHOA! One of the best tacos I have ever tasted &#8211; they were phenomenal! Can&#8217;t wait to try this lighter shrimp version.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T11:38:20-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583974">04/07/15 @ 11:38 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583974" data-commentid="583974" data-postid="23546" data-belowelement="comment-583974" data-respondelement="respond" data-replyto="Reply to Whitney @ Sweet Cayenne" aria-label="Reply to Whitney @ Sweet Cayenne">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-even depth-1" id="comment-583975">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/404c4a64b9cb19f5d714971800c14b8b8e0590b5e263964dc28586dc07530a4d?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/404c4a64b9cb19f5d714971800c14b8b8e0590b5e263964dc28586dc07530a4d?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Kimber"/>
+				<cite class="fn"><a href="https://kimberwidmer.com/" class="url" rel="ugc external nofollow">Kimber</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Can&#8217;t wait to try these… but WOW on the taco holders. YIKES that&#8217;s pricey. Will have to go with bean tacos if I bought these puppies.<br />
+I&#8217;m obsessed with all things cilantro and avocado. Can&#8217;t wait to give these a spin. I will be serving them in my tried and true, yet somewhat plasticy Tupperware taco holders.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T11:41:20-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583975">04/07/15 @ 11:41 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583975" data-commentid="583975" data-postid="23546" data-belowelement="comment-583975" data-respondelement="respond" data-replyto="Reply to Kimber" aria-label="Reply to Kimber">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment even depth-2" id="comment-583984">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/37597de13b78dddacb844be14b50aca7a5dc266c6f6104b600bb5a4eb3a04313?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/37597de13b78dddacb844be14b50aca7a5dc266c6f6104b600bb5a4eb3a04313?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="john godino"/>
+				<cite class="fn">john godino</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Kimber,  the taco holders are pretty nifty, but try a quick google first.  Multiple options are available, many of them for under $4 rather than 22.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T12:29:08-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583984">04/07/15 @ 12:29 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583984" data-commentid="583984" data-postid="23546" data-belowelement="comment-583984" data-respondelement="respond" data-replyto="Reply to john godino" aria-label="Reply to john godino">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-odd thread-alt depth-1" id="comment-583976">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/0ac68e683d7068fd3cccf7da0c98cce8159ba2ec352e245d73161d61e9e8c275?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/0ac68e683d7068fd3cccf7da0c98cce8159ba2ec352e245d73161d61e9e8c275?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Belinda Lo"/>
+				<cite class="fn"><a href="http://themoonblushbaker.com" class="url" rel="ugc external nofollow">Belinda Lo</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I am not sure I would ever fork out that much for one use appliance/utensils even if didi hold one of the best dinners in the world. I am love seafood in tacos; they remind me of fresh California  summers thanks to the light, tangy slaw and the sweet seafood in a warm flat bread.  Pass me a beer and one these thank you any day of the week!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T11:47:12-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583976">04/07/15 @ 11:47 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583976" data-commentid="583976" data-postid="23546" data-belowelement="comment-583976" data-respondelement="respond" data-replyto="Reply to Belinda Lo" aria-label="Reply to Belinda Lo">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-lindsay bypostauthor even depth-2" id="comment-584046">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Lindsay"/>
+				<cite class="fn"><a href="https://pinchofyum.com" class="url" rel="ugc">Lindsay</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Hi Belinda! The company I linked to increased their price in the short time between posting and your comment. Wows! I&#8217;ve updated the link to a more affordable option from a different seller.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-08T15:41:10-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-584046">04/08/15 @ 3:41 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-584046" data-commentid="584046" data-postid="23546" data-belowelement="comment-584046" data-respondelement="respond" data-replyto="Reply to Lindsay" aria-label="Reply to Lindsay">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-even depth-1" id="comment-583977">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/7e9eb5f6d34b745a484dc0af0893babc855858989d566bebe86c842933f11c97?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/7e9eb5f6d34b745a484dc0af0893babc855858989d566bebe86c842933f11c97?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Simple Green Moms"/>
+				<cite class="fn"><a href="https://simplegreenmoms.com/" class="url" rel="ugc external nofollow">Simple Green Moms</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>we had some super delish tacos at a DMB concert last summer and haven&#8217;t been able to recreate anything quite as flavorful ever since. kind of thinking these may do the trick!!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T11:50:45-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583977">04/07/15 @ 11:50 am</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583977" data-commentid="583977" data-postid="23546" data-belowelement="comment-583977" data-respondelement="respond" data-replyto="Reply to Simple Green Moms" aria-label="Reply to Simple Green Moms">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment even thread-odd thread-alt depth-1" id="comment-583980">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/dfff63f0cb2f0f17a868029b77375b7aae22d49e307362dbd91100e167b5da9c?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/dfff63f0cb2f0f17a868029b77375b7aae22d49e307362dbd91100e167b5da9c?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Medha @ Whisk &amp; Shout"/>
+				<cite class="fn"><a href="http://whiskandshout.com/" class="url" rel="ugc external nofollow">Medha @ Whisk &amp; Shout</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>These photos are so so lovely! I love tacos and you&#8217;re making me hungry at work, girl 🙂</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T12:07:55-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583980">04/07/15 @ 12:07 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583980" data-commentid="583980" data-postid="23546" data-belowelement="comment-583980" data-respondelement="respond" data-replyto="Reply to Medha @ Whisk &amp; Shout" aria-label="Reply to Medha @ Whisk &amp; Shout">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-even depth-1" id="comment-583981">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/f0ced1e033bf7ecc88983ce2da076374a3e48f080c20f917af29f0f258c3e27e?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/f0ced1e033bf7ecc88983ce2da076374a3e48f080c20f917af29f0f258c3e27e?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Andrea @ My Tasty Kitchen"/>
+				<cite class="fn"><a href="http://www.mytastykitchen.com" class="url" rel="ugc external nofollow">Andrea @ My Tasty Kitchen</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>What was the name of the restaurant? Those tacos sound amazing!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T12:10:50-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583981">04/07/15 @ 12:10 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583981" data-commentid="583981" data-postid="23546" data-belowelement="comment-583981" data-respondelement="respond" data-replyto="Reply to Andrea @ My Tasty Kitchen" aria-label="Reply to Andrea @ My Tasty Kitchen">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment byuser comment-author-lindsay bypostauthor even depth-2" id="comment-584047">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/01d6c6c84a4d6ca008d4757735105352a2aae339a608984789726534e9a8a5fd?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Lindsay"/>
+				<cite class="fn"><a href="https://pinchofyum.com" class="url" rel="ugc">Lindsay</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Simmzy&#8217;s in Long Beach!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-08T15:41:26-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-584047">04/08/15 @ 3:41 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-584047" data-commentid="584047" data-postid="23546" data-belowelement="comment-584047" data-respondelement="respond" data-replyto="Reply to Lindsay" aria-label="Reply to Lindsay">Reply</a>			</div>
+		</div>
+	</article>
+<ol class="children">
+
+<li class="comment odd alt depth-3" id="comment-805713">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/c4c9ce1c4684d75ed40c0b250e91a1bb9db855b9280e6ac58c789caea63ba7d9?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/c4c9ce1c4684d75ed40c0b250e91a1bb9db855b9280e6ac58c789caea63ba7d9?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Kelsey"/>
+				<cite class="fn">Kelsey</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I made this dish last night and it was disturbingly salty and just&#8230; not very good. Never again.</p>
+</div><p class="tasty-recipes-ratings"><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="2"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="100" data-rating="2"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="0" data-rating="2"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="0" data-rating="2"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span><span class="tasty-recipes-rating tasty-recipes-rating-outline" data-tr-clip="0" data-rating="2"><svg role="presentation" aria-hidden="true"><use xlink:href="#wpt-star-full"></use></svg></span></p>
+			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2020-06-02T14:47:44-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-805713">06/02/20 @ 2:47 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-805713" data-commentid="805713" data-postid="23546" data-belowelement="comment-805713" data-respondelement="respond" data-replyto="Reply to Kelsey" aria-label="Reply to Kelsey">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+</ol><!-- .children -->
+</li><!-- #comment-## -->
+
+<li class="comment even thread-odd thread-alt depth-1" id="comment-583982">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/6c3a3fb07d16e6032b6e68fa9e56d177e1a0bd3a88dbcbb5db4918efa9cae9dd?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/6c3a3fb07d16e6032b6e68fa9e56d177e1a0bd3a88dbcbb5db4918efa9cae9dd?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Susan"/>
+				<cite class="fn">Susan</cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>Since my husband doesn&#8217;t like shrimp (except breaded, which I&#8217;m not going to do) I&#8217;m saving this for the slaw part of the recipe.  I will probably use Greek yogurt in place of the sour cream &#8211; similar flavor and I always have some on hand.  One day I&#8217;ll be able to do the whole shrimp taco (oh, forgot to mention that my husband also doesn&#8217;t like avocados…) as the recipe is written.</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T12:16:26-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583982">04/07/15 @ 12:16 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583982" data-commentid="583982" data-postid="23546" data-belowelement="comment-583982" data-respondelement="respond" data-replyto="Reply to Susan" aria-label="Reply to Susan">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+
+<li class="comment odd alt thread-even depth-1" id="comment-583985">
+	<article class="flow-root" itemprop="comment" itemscope="" itemtype="https://schema.org/Comment">
+		<div class="comment-image">
+			<img data-pin-nopin="nopin" loading="lazy" nopin="nopin" alt="Pinch of Yum Logo" src="https://secure.gravatar.com/avatar/8a16d6201a56c2f624b6ef2cfbbd153ed880f533e416b763a42996986759795e?s=75&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-75x75.jpg&#038;r=g" srcset="https://secure.gravatar.com/avatar/8a16d6201a56c2f624b6ef2cfbbd153ed880f533e416b763a42996986759795e?s=150&#038;d=https%3A%2F%2Fpinchofyum.com%2Fcontent%2Fassets%2Fimages%2Fpoy-avatar-grey-150x150.jpg&#038;r=g 2x" class='avatar avatar-75 photo' height='75' width='75' loading='lazy' decoding='async'/>		</div>
+		<div class="comment-content">
+			<div class="comment-author vcard" itemprop="author" itemscope="" itemtype="https://schema.org/Person">
+				<meta itemprop="name" content="Megan"/>
+				<cite class="fn"><a href="http://foodiocentric.com" class="url" rel="ugc external nofollow">Megan</a></cite>			</div>
+						<div class="comment-text w-full" itemprop="text"><p>I was already planning on making fish tacos this week, now I am definitely using this recipe. I have been hunting for a good taco slaw for awhile, can&#8217;t wait to try!!</p>
+</div>			<div class="comment-meta commentmetadata">
+				<meta itemprop="datePublished" content="2015-04-07T12:32:04-05:00"/>
+				<a href="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw#comment-583985">04/07/15 @ 12:32 pm</a>
+											</div>
+			<div class="comment-reply">
+				<a rel="nofollow" class="comment-reply-link" href="#comment-583985" data-commentid="583985" data-postid="23546" data-belowelement="comment-583985" data-respondelement="respond" data-replyto="Reply to Megan" aria-label="Reply to Megan">Reply</a>			</div>
+		</div>
+	</article>
+</li><!-- #comment-## -->
+		</ol><!-- .comment-list -->
+
+		
+</div><!-- #comments -->
+<div style="text-align: center;">
+	<button class="poy-load-more-comments" type="button">Load More Comments</button>
+</div>
+<script>
+(function() {
+	var	baseUrl = "https:\/\/pinchofyum.com\/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?poy-next-comments=%%next%%",
+		currentPage = 1,
+		totalPages = 21;
+	document.querySelector('.poy-load-more-comments').addEventListener('click', function( event ) {
+		event.preventDefault();
+		event.target.disabled = true;
+		currentPage++;
+
+		var scrollPos = window.scrollY;
+		var oReq = new XMLHttpRequest();
+		oReq.addEventListener('load', function() {
+			event.target.disabled = false;
+			document.querySelector('.comment-list').innerHTML += this.responseText;
+			window.scrollTo( 0, scrollPos );
+			if (currentPage >= totalPages) {
+				event.target.remove();
+			}
+		});
+		oReq.open('GET', baseUrl.replace('%%next%%', currentPage));
+		oReq.send();
+	});
+}())
+</script>
+					</article>
+				
+<aside class="col-start-9 col-span-4">
+
+	
+<style>
+/* CLS updates for sidebar */
+@media (min-width: 768px) {
+	.md\:mt-12 {
+		margin-top: 3rem;
+	}
+}
+.col-start-9 {
+	grid-column-start: 9;
+}
+
+h1.entry-title {
+	--tw-text-opacity: 1;
+	color: rgb(26 26 26 / var(--tw-text-opacity));
+	font-family: Domaine Display, Georgia, Cambria, Times New Roman, Times,
+		serif;
+	font-size: 2rem;
+	line-height: 1.125;
+}
+@media screen and (min-width: 768px) {
+	h1.entry-title {
+		font-size: 2.625rem;
+	}
+}
+</style>
+
+<section class="hidden md:block bg-gray-200 mb-6 mt-24 p-6 text-center">
+	<img
+		class="h-48 w-48 -mt-24 mx-auto inline-block rounded-full"
+		alt="Lindsay in the kitchen"
+		src="https://pinchofyum.com/content/assets/images/sidebar/sidebar-lindsay.jpg"
+		sizes="(min-width: 780px) 192px"
+		height="192"
+		width="192"
+		loading="eager"
+		data-pin-nopin="true"></a>
+	<h3 class="my-6 flex flex-col justify-center text-black text-base font-arvo uppercase tracking-widest">
+		<span>Hi! I’m Lindsay.</span>
+		<span class="sidebar-heading-you">Nice to Meet You!</span>
+	</h3>
+	<p class="mt-10 text-gray-600 text-kinda-sm leading-loose">I'm a former 4th grade teacher, now full time blogger. My husband Bjork and I live in Minnesota. Favorite things include my camera, lake days, and dark chocolate.</p>
+	<p class="mt-6 font-sans uppercase font-bold tracking-widest"><a class="text-purple-500 hover:text-black" href="https://pinchofyum.com/about">Learn More</a></p>
+</section>
+
+	<section class="bg-gray-700 p-6 mt-6">
+		<h5 class="mb-2 font-arvo uppercase tracking-widest text-white text-base text-center">Follow Us</h5>
+		<div class="mt-4 flex justify-evenly space-x-2">
+						<a target="_blank" href="https://www.instagram.com/pinchofyum" rel="noopener"><svg class="w-10 h-10 p-1 bg-white text-gray-900 rounded-full flex items-center justify-center hover:bg-opacity-50"><title>INSTAGRAM</title><desc>INSTAGRAM icon</desc><use xlink:href="#sprite-icon-instagram"></use></svg></a>
+						<a target="_blank" href="https://www.pinterest.com/pinchofyum/_created/" rel="noopener"><svg class="w-10 h-10 p-1 bg-white text-gray-900 rounded-full flex items-center justify-center hover:bg-opacity-50"><title>PINTEREST</title><desc>PINTEREST icon</desc><use xlink:href="#sprite-icon-pinterest"></use></svg></a>
+						<a target="_blank" href="https://www.tiktok.com/@pinchofyum" rel="noopener"><svg class="w-10 h-10 p-1 bg-white text-gray-900 rounded-full flex items-center justify-center hover:bg-opacity-50"><title>TIKTOK</title><desc>TIKTOK icon</desc><use xlink:href="#sprite-icon-tiktok"></use></svg></a>
+						<a target="_blank" href="https://www.facebook.com/pinchofyum" rel="noopener"><svg class="w-10 h-10 p-1 bg-white text-gray-900 rounded-full flex items-center justify-center hover:bg-opacity-50"><title>FACEBOOK</title><desc>FACEBOOK icon</desc><use xlink:href="#sprite-icon-facebook"></use></svg></a>
+						<a target="_blank" href="https://twitter.com/pinchofyum" rel="noopener"><svg class="w-10 h-10 p-1 bg-white text-gray-900 rounded-full flex items-center justify-center hover:bg-opacity-50"><title>TWITTER</title><desc>TWITTER icon</desc><use xlink:href="#sprite-icon-twitter"></use></svg></a>
+						<a target="_blank" href="https://www.youtube.com/pinchofyum" rel="noopener"><svg class="w-10 h-10 p-1 bg-white text-gray-900 rounded-full flex items-center justify-center hover:bg-opacity-50"><title>YOUTUBE</title><desc>YOUTUBE icon</desc><use xlink:href="#sprite-icon-youtube"></use></svg></a>
+					</div>
+		<div class="flex flex-wrap md:flex-nowrap justify-center mt-8 md:-mb-2">
+			<p class="followbar-signup mb-6 leading-3 flex space-x-2 justify-center font-arvo uppercase tracking-widest text-white">
+				<span class="signup">signup </span>
+				<span class="leading-tight">for Email Updates</span>
+			</p>
+		</div>
+		<p class="text-white italic text-center text-sm md:text-kinda-sm">Get a Free eCookbook with our top 25 recipes.</p>
+		<script async data-uid="f83b053758" src="https://pinchofyum.ck.page/f83b053758/index.js"></script>
+	</section>
+
+	<section class="p-4 mt-6 p-6 bg-gray-200 text-center">
+		<h3 class="my-6 flex flex-col justify-center text-black text-base font-arvo uppercase tracking-widest text-purple-500">
+			<span>Follow our 10 Year</span>
+			<span class="sidebar-heading-you">journey</span>
+			<span class="mt-4">to Blogging Full-time</span>
+		</h3>
+		<img class="h-48 w-48 mx-auto" alt="Lindsay and Bjork" src="https://pinchofyum.com/content/assets/images/lindsay-bjork.jpg" height="242" width="242" loading="lazy" data-pin-nopin="true"></a>
+		<p class="mt-8 mb-2 font-sans uppercase font-bold tracking-widest"><a class="text-purple-500 hover:text-black" href="https://pinchofyum.com/category/making-money-from-a-food-blog">Learn More</a></p>
+	</section>
+</aside>
+	</div>
+	
+<div class="bg-gray-700 top-recipes-footer">
+	<div class="py-8 px-4 lg:px-0 md:max-w-4xl mx-auto">
+		<div class="md:flex space-x-4 items-center">
+			<div class="md:w-1/2 mb-4">
+				<img
+					width="800"
+					height="600"
+					loading="lazy"
+					data-pin-nopin="true"
+					alt="ebook cover"
+					src="https://pinchofyum.com/content/assets/images/cta/poy-ecookbook-2021.png"
+					srcset="https://pinchofyum.com/content/assets/images/cta/poy-ecookbook-2021-450x338.png 450w, https://pinchofyum.com/content/assets/images/cta/poy-ecookbook-2021.png 800w"
+					sizes="(min-width: 980px) 416px, (min-width: 780px) calc(32.22vw + 115px), calc(100vw - 32px)"
+					/>
+			</div>
+			<div class="md:w-1/2 text-center">
+				<p class="flex flex-col mb-4 font-arvo uppercase tracking-widest text-white text-2xl">
+					<span class="footer-get-it-now">Get it Now</span>
+					<span>Pinch of Yum Cookbook</span>
+				</p>
+				<p class="mb-4 text-gray-100 md:text-lg">The eBook includes our most popular 25 recipes in a beautiful, easy to download format. Enter your email and we'll send it right over!</p>
+				<script async data-uid="f83b053758" src="https://pinchofyum.ck.page/f83b053758/index.js"></script>
+			</div>
+		</div>
+	</div>
+</div>
+</main>
+<div class="footer border-t">
+<div class="pt-4 md:pt-10 px-4 md:max-w-6xl mx-auto md:grid md:grid-cols-2">
+	<div>
+		<div class="grid grid-cols-2">
+			<div>
+				<h4 class="mb-2 font-arvo not-italic bold tracking-widest text-xs uppercase text-gray-700">Pinch of Yum</h4>
+				<ul>
+					<li><a href="https://pinchofyum.com/about">About</a></li>
+					<li><a href="https://pinchofyum.com/blog">Blog</a></li>
+					<li><a href="https://pinchofyum.com/recipes">Recipe Index</a></li>
+					<li><a href="https://pinchofyum.com/resources">Blogging Resources</a></li>
+					<li><a href="https://pinchofyum.com/category/making-money-from-a-food-blog">Income Reports</a></li>
+					<li><a href="https://pinchofyum.com/sponsored-content">Sponsored Content</a></li>
+					<li><a href="https://pinchofyum.com/media-mentions">Media Mentions</a></li>
+					<li><a href="https://pinchofyum.com/contact">Contact</a></li>
+				</ul>
+			</div>
+			<div>
+				<h4 class="mb-2 font-arvo not-italic bold tracking-widest text-xs uppercase text-gray-700">Food &amp; Recipes</h4>
+				<ul>
+					<li><a href="https://pinchofyum.com/everything-you-need-to-know-about-sugar-free-january">Sugar Free January</a></li>
+					<li><a href="https://pinchofyum.com/freezer-meals">Freezer Meals 101</a></li>
+					<li><a href="https://pinchofyum.com/recipes/quick-and-easy">Quick and Easy Recipes</a></li>
+					<li><a href="https://pinchofyum.com/recipes/instant-pot">Instant Pot Recipes</a></li>
+					<li><a href="https://pinchofyum.com/recipes/pasta">Pasta Recipes</a></li>
+					<li><a href="https://pinchofyum.com/recipes/vegan">Vegan Recipes</a></li>
+					<li><a href="https://pinchofyum.com/recipes/soup">Soup Recipes</a></li>
+					<li><a href="https://pinchofyum.com/recipes/taco">Taco Recipes</a></li>
+					<li><a href="https://pinchofyum.com/recipes/meal-prep">Meal Prep Recipes</a></li>
+				</ul>
+			</div>
+		</div>
+		<div class="flex justify-center md:justify-start pt-6 md:pt-10 space-x-4">
+							<a target="_blank" class="block w-9 h-9 bg-purple-500 hover:bg-gray-700 rounded-full flex items-center justify-center" href="https://www.instagram.com/pinchofyum" rel="noopener"><svg class="w-7 h-7 text-white"><title>INSTAGRAM</title><desc>INSTAGRAM icon</desc><use xlink:href="#sprite-icon-instagram"></use></svg></a>
+							<a target="_blank" class="block w-9 h-9 bg-purple-500 hover:bg-gray-700 rounded-full flex items-center justify-center" href="https://www.pinterest.com/pinchofyum/_created/" rel="noopener"><svg class="w-7 h-7 text-white"><title>PINTEREST</title><desc>PINTEREST icon</desc><use xlink:href="#sprite-icon-pinterest"></use></svg></a>
+							<a target="_blank" class="block w-9 h-9 bg-purple-500 hover:bg-gray-700 rounded-full flex items-center justify-center" href="https://www.tiktok.com/@pinchofyum" rel="noopener"><svg class="w-7 h-7 text-white"><title>TIKTOK</title><desc>TIKTOK icon</desc><use xlink:href="#sprite-icon-tiktok"></use></svg></a>
+							<a target="_blank" class="block w-9 h-9 bg-purple-500 hover:bg-gray-700 rounded-full flex items-center justify-center" href="https://www.facebook.com/pinchofyum" rel="noopener"><svg class="w-7 h-7 text-white"><title>FACEBOOK</title><desc>FACEBOOK icon</desc><use xlink:href="#sprite-icon-facebook"></use></svg></a>
+							<a target="_blank" class="block w-9 h-9 bg-purple-500 hover:bg-gray-700 rounded-full flex items-center justify-center" href="https://twitter.com/pinchofyum" rel="noopener"><svg class="w-7 h-7 text-white"><title>TWITTER</title><desc>TWITTER icon</desc><use xlink:href="#sprite-icon-twitter"></use></svg></a>
+							<a target="_blank" class="block w-9 h-9 bg-purple-500 hover:bg-gray-700 rounded-full flex items-center justify-center" href="https://www.youtube.com/pinchofyum" rel="noopener"><svg class="w-7 h-7 text-white"><title>YOUTUBE</title><desc>YOUTUBE icon</desc><use xlink:href="#sprite-icon-youtube"></use></svg></a>
+					</div>
+		<div class="flex flex-wrap md:flex-nowrap justify-center md:justify-start items-center pt-10">
+			<svg class="w-48 sm:w-56 md:mr-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 388.7 87">
+  <g id="Layer_2" data-name="Layer 2">
+    <g id="Layer_1-2" data-name="Layer 1">
+      <g>
+        <g>
+          <path d="M20,19.4A20.6,20.6,0,0,0,8.9,23.2V20.5a1,1,0,0,0-1.1-1.1H2.9l-.7.4a.8.8,0,0,0-.3.7v.5a1.1,1.1,0,0,0,.3.7.9.9,0,0,0,.7.3h.8a6.7,6.7,0,0,1,2.1.2H6V67H5.9a9.1,9.1,0,0,1-3.6.5H1a1.1,1.1,0,0,0-.7.3.8.8,0,0,0-.3.7v.5a1.1,1.1,0,0,0,.3.7,1.1,1.1,0,0,0,.7.3H15.1a1.1,1.1,0,0,0,.7-.3,1.1,1.1,0,0,0,.3-.8v-.4a1.1,1.1,0,0,0-.3-.8,1.1,1.1,0,0,0-.7-.3H12.7a8.1,8.1,0,0,1-3.6-.4H8.9V49.5A14.5,14.5,0,0,0,13,53.2a13.9,13.9,0,0,0,6.7,1.7,14.2,14.2,0,0,0,11-5.1,19.4,19.4,0,0,0,4.2-12.7,19.3,19.3,0,0,0-4.2-12.6A13.6,13.6,0,0,0,20,19.4Zm-.3,32.8a10.7,10.7,0,0,1-6.8-2.3,12.9,12.9,0,0,1-4-6.2V26.5c3.7-2.8,7.5-4.4,11.1-4.4a11,11,0,0,1,8.6,4.1A17.7,17.7,0,0,1,32,37.1,16.7,16.7,0,0,1,28.5,48,11,11,0,0,1,19.7,52.2Z" style="fill: #734060"/>
+          <path d="M46.5,12a2.4,2.4,0,0,0,1.7-.7,2.4,2.4,0,0,0,.7-1.6,2.2,2.2,0,0,0-.7-1.6,2.2,2.2,0,0,0-1.7-.7,2.4,2.4,0,0,0-2.3,2.3A2.4,2.4,0,0,0,46.5,12Z" style="fill: #734060"/>
+          <path d="M53,52.2H51.9a9.2,9.2,0,0,1-3.6-.4h-.2V20.4a1.1,1.1,0,0,0-.3-.7,1.1,1.1,0,0,0-.8-.3H42.1a.8.8,0,0,0-.7.3,1.1,1.1,0,0,0-.3.7V21a1.1,1.1,0,0,0,.3.8,1.5,1.5,0,0,0,.7.3h.8a4.5,4.5,0,0,1,2.1.2h.2V51.5h-.1a10.1,10.1,0,0,1-3.6.4H40.2a.9.9,0,0,0-.7.3,1.1,1.1,0,0,0-.3.7v.5a.8.8,0,0,0,.3.7.9.9,0,0,0,.7.3H53a1.1,1.1,0,0,0,.7-.3.9.9,0,0,0,.3-.7v-.5a.9.9,0,0,0-.3-.7A1.1,1.1,0,0,0,53,52.2Z" style="fill: #734060"/>
+          <path d="M98.3,52.1H97a8.1,8.1,0,0,1-3.6-.4.1.1,0,0,1-.1-.1h-.1V29.3a10,10,0,0,0-.8-4.3,8,8,0,0,0-4-4.3,15.2,15.2,0,0,0-6.8-1.4,14.2,14.2,0,0,0-9,3.6,21.4,21.4,0,0,0-4.8,5.9V20.4a1,1,0,0,0-1-1H61.9a1.1,1.1,0,0,0-.8.3,1.1,1.1,0,0,0-.3.7V21a.9.9,0,0,0,.3.7,1.1,1.1,0,0,0,.8.3h.8a6,6,0,0,1,2.1.3h.1s.1,0,.1.2V51.5h0c0,.1,0,.1-.2.2a11.7,11.7,0,0,1-3.5.4H60a1.1,1.1,0,0,0-.8.3,1.5,1.5,0,0,0-.3.7v.5a1,1,0,0,0,.4.7.8.8,0,0,0,.7.3H73.4a.9.9,0,0,0,.7-.3,1.1,1.1,0,0,0,.3-.7v-.5a.9.9,0,0,0-.3-.7,1.1,1.1,0,0,0-.7-.3H71.6a8,8,0,0,1-3.5-.5h-.2V38.9a18.7,18.7,0,0,1,4.3-11.7,15.2,15.2,0,0,1,4.4-3.7,10.8,10.8,0,0,1,5-1.4c3.1,0,5.3.7,6.6,1.9a6,6,0,0,1,1.6,2.2,9.8,9.8,0,0,1,.5,3.2V51.6h-.1a.1.1,0,0,1-.1.1,9.1,9.1,0,0,1-3.6.5H84.9a1.1,1.1,0,0,0-.8.3.9.9,0,0,0-.3.7v.5a1.1,1.1,0,0,0,.3.7,1.1,1.1,0,0,0,.8.3H98.3a1,1,0,0,0,1-1v-.5a1.1,1.1,0,0,0-.3-.8A1.1,1.1,0,0,0,98.3,52.1Z" style="fill: #734060"/>
+          <path d="M130.3,48.3a1,1,0,0,0-1.4-.1,17.5,17.5,0,0,1-11.1,3.9,13.9,13.9,0,0,1-10.4-4.2,15.2,15.2,0,0,1-4-10.8,15.8,15.8,0,0,1,3.8-10.9,13,13,0,0,1,9.9-4.2,15.7,15.7,0,0,1,7,1.6,7.2,7.2,0,0,1,2.1,1.6c.5.5,0,1.3,0,1.7a1.8,1.8,0,0,0,.6,1.6,2.2,2.2,0,0,0,1.8.3c.8-.2,1.1-.4,1.3-.8a2.4,2.4,0,0,0,.4-1.3,4.2,4.2,0,0,0-1.2-2.8,12,12,0,0,0-4.8-3.3,19.7,19.7,0,0,0-7.2-1.3,16.1,16.1,0,0,0-11.9,5.1,18,18,0,0,0-4.7,12.7,17.8,17.8,0,0,0,4.9,12.7,16.9,16.9,0,0,0,12.4,5,20.2,20.2,0,0,0,12.8-4.5,2,2,0,0,0,.4-.8,1.1,1.1,0,0,0-.3-.7Z" style="fill: #734060"/>
+          <path d="M173,52.1h-1.3a9.1,9.1,0,0,1-3.6-.5c-.1,0-.1,0-.1-.1h0V29.2a11.8,11.8,0,0,0-.7-4.3,9.2,9.2,0,0,0-4-4.3,15.9,15.9,0,0,0-6.8-1.4,14,14,0,0,0-9,3.6,19.8,19.8,0,0,0-4.8,5.9V5a1,1,0,0,0-.4-.7.9.9,0,0,0-.7-.3h-5.6a1,1,0,0,0-1,1v.5a.8.8,0,0,0,.3.7,1.1,1.1,0,0,0,.7.3h1.5a6,6,0,0,1,2.1.3h.2V51.4h-.1a10.1,10.1,0,0,1-3.6.4h-1.3a.9.9,0,0,0-.7.3,1.1,1.1,0,0,0-.3.7v.5a.8.8,0,0,0,.3.7.9.9,0,0,0,.7.3h13.4a1,1,0,0,0,1-1v-.5a1,1,0,0,0-1-1h-1.7a9.2,9.2,0,0,1-3.6-.4h-.2V38.9A18.6,18.6,0,0,1,147,27.2a17.4,17.4,0,0,1,4.4-3.8,10.2,10.2,0,0,1,5-1.4c3,0,5.1.7,6.5,1.9a6,6,0,0,1,1.6,2.2,7.6,7.6,0,0,1,.6,3.2V51.5h-.2a8.3,8.3,0,0,1-3.6.5h-1.7a.8.8,0,0,0-.7.3.9.9,0,0,0-.3.7v.5a1,1,0,0,0,1,1H173a.9.9,0,0,0,.7-.3,1.1,1.1,0,0,0,.3-.7v-.5a1,1,0,0,0-1-1Z" style="fill: #734060"/>
+          <path d="M283.1,19.3H270.4a1.1,1.1,0,0,0-.7.3.9.9,0,0,0-.3.7v.5a1,1,0,0,0,1,1h3.2a14.8,14.8,0,0,1,3.5.2h.3l-.2.5L265.6,50,255,24.5h0l-1-2.3-.8-1.3a4.9,4.9,0,0,0-1.8-1.4,5.3,5.3,0,0,0-2.3-.4,4.7,4.7,0,0,0-1.5.2,2.4,2.4,0,0,0-1,.5,1.2,1.2,0,0,0-.5.5,1.9,1.9,0,0,0-.2.8c0,.2.1.4.1.6a1.8,1.8,0,0,0,.7.8l.9.2h.5a2.7,2.7,0,0,1,1.2-.2h1.4a2.8,2.8,0,0,1,.6.8,21.7,21.7,0,0,1,1,2.1h0l11.2,27.1h0l.3.9a.4.4,0,0,1,.1.3c0,.1,0,.2.1.2l-.2.3h0c-1.7,4-3.4,7.3-5.4,9.5a11.8,11.8,0,0,1-3.1,2.5,8.2,8.2,0,0,1-3.5.8,8.5,8.5,0,0,1-4.7-1.2,4.5,4.5,0,0,1-1.2-1.2,2.9,2.9,0,0,1-.4-1.6c0-.3,1-1.1,1-2.2a2,2,0,0,0-.9-1.8,2.5,2.5,0,0,0-2.7.3,3.7,3.7,0,0,0-.6,1,5.6,5.6,0,0,0-.3,2.2,6.3,6.3,0,0,0,.7,3,7.3,7.3,0,0,0,3.6,3.1,13.1,13.1,0,0,0,5.5,1.1,10.8,10.8,0,0,0,4.7-1.1,15.6,15.6,0,0,0,5.5-5.1,42.8,42.8,0,0,0,4.3-8.3l13.4-31.8h0a1.9,1.9,0,0,1,1-1.3,4.8,4.8,0,0,1,2.1-.4h.3a1.1,1.1,0,0,0,.8-.3,1.1,1.1,0,0,0,.3-.7v-.5a.8.8,0,0,0-.3-.7A.8.8,0,0,0,283.1,19.3Z" style="fill: #734060"/>
+          <polygon points="244.4 60.5 244.4 60.5 244.4 60.5 244.4 60.5" style="fill: #734060"/>
+          <path d="M323.9,51.4l-2.9.5c0-.1-.1-.1-.1-.2a6.7,6.7,0,0,1-.6-1.2,10.6,10.6,0,0,1-.4-1.9h0l-.3-3.2V20.1a1,1,0,0,0-1-1h-5a1.1,1.1,0,0,0-.7.3,1.1,1.1,0,0,0-.3.8v.4a1.1,1.1,0,0,0,.3.8,1.1,1.1,0,0,0,.7.3h.8a8.2,8.2,0,0,1,2.2.2h.1a.3.3,0,0,1,.1.2V35a18.2,18.2,0,0,1-4.4,11.7,15.6,15.6,0,0,1-4.4,3.8,11.3,11.3,0,0,1-5,1.3c-3.1,0-5.3-.7-6.6-1.8a6.9,6.9,0,0,1-1.6-2.2,10.2,10.2,0,0,1-.5-3.2V20.2a1,1,0,0,0-1.1-1.1h-4.9a1,1,0,0,0-1,1.1v.5a1.1,1.1,0,0,0,.3.7.9.9,0,0,0,.7.3h.8a6.7,6.7,0,0,1,2.1.2h.2V44.7a11.2,11.2,0,0,0,.8,4.2,8,8,0,0,0,4,4.3,14,14,0,0,0,6.8,1.4,14.5,14.5,0,0,0,9-3.5,21.9,21.9,0,0,0,4.8-6v.4h0l.3,3.2h0a9.3,9.3,0,0,0,1,3.7,5.8,5.8,0,0,0,1.1,1.5,3.5,3.5,0,0,0,1.8.6h.2l3.1-.5c.3-.1.6-.2.7-.5a1,1,0,0,0,.2-.7v-.7A1.2,1.2,0,0,0,323.9,51.4Z" style="fill: #734060"/>
+          <path d="M388.4,52.1a1.1,1.1,0,0,0-.8-.3h-1.2a9.2,9.2,0,0,1-3.6-.4h-.2V28.9a10.7,10.7,0,0,0-.7-4.1,8.1,8.1,0,0,0-3.5-4.4,12.8,12.8,0,0,0-6.1-1.4,12.6,12.6,0,0,0-8.6,3.6,19,19,0,0,0-4,5.2,13.3,13.3,0,0,0-.6-3,8.7,8.7,0,0,0-3.6-4.4,13.2,13.2,0,0,0-6.2-1.4,12.8,12.8,0,0,0-8.6,3.6,22.2,22.2,0,0,0-3.9,5.1V20.1a1,1,0,0,0-1-1h-5a1,1,0,0,0-1,1v.5a.8.8,0,0,0,.3.7,1.1,1.1,0,0,0,.7.3h.8a6.8,6.8,0,0,1,2.2.3h.1V51.2h-.2a9.2,9.2,0,0,1-3.6.4H329a1.1,1.1,0,0,0-.8.3,1.1,1.1,0,0,0-.3.7v.5a.9.9,0,0,0,.3.7,1.1,1.1,0,0,0,.8.3h13.4a1.1,1.1,0,0,0,.7-.3.9.9,0,0,0,.3-.7v-.5a.9.9,0,0,0-.3-.7,1.1,1.1,0,0,0-.8-.3h-1.7a10.1,10.1,0,0,1-3.6-.4h-.1V38.7a20.3,20.3,0,0,1,3.8-11.8,11.7,11.7,0,0,1,4-3.7,9.2,9.2,0,0,1,4.7-1.4,11.1,11.1,0,0,1,3.4.5,5.7,5.7,0,0,1,3.1,2.3,8.3,8.3,0,0,1,1.1,4.5V51.3h0a.1.1,0,0,1-.1.1,9.1,9.1,0,0,1-3.6.5h-1a1.1,1.1,0,0,0-.7.3.9.9,0,0,0-.3.7v.5a.9.9,0,0,0,.3.7,1.1,1.1,0,0,0,.7.3h12.3a.8.8,0,0,0,.7-.3,1.3,1.3,0,0,0,.4-.7v-.5a.8.8,0,0,0-.4-.7.8.8,0,0,0-.7-.3h-.9a8.3,8.3,0,0,1-3.6-.5h-.2V38.6a20.4,20.4,0,0,1,3.7-11.8,13.5,13.5,0,0,1,4-3.6,9.2,9.2,0,0,1,4.8-1.4,11.6,11.6,0,0,1,3.4.5,5.8,5.8,0,0,1,3,2.3,9.2,9.2,0,0,1,1,4.4V51.3h0a.1.1,0,0,1-.1.1,10.1,10.1,0,0,1-3.6.4h-1l-.7.3a1.1,1.1,0,0,0-.3.8v.5a1,1,0,0,0,1,1h12.6a1,1,0,0,0,1.1-1.1v-.4A1.1,1.1,0,0,0,388.4,52.1Z" style="fill: #734060"/>
+        </g>
+        <path d="M236.4,41.5h-.6a1.6,1.6,0,0,0-1.2.6,20.2,20.2,0,0,1-2.6,3.2,16.1,16.1,0,0,1-3,2.1,16.3,16.3,0,0,1-3.7,1.3l-2.3.2h-3.3l-2.9-.6-.4-.2c-.1-.1-.3-.2-.3-.4a.5.5,0,0,1,0-.6h0c.1-.6.1-1.2.2-1.8h0c.1-.5.1-1,.2-1.6a1.5,1.5,0,0,1,.3-.7h0l2.1-2.3,2.2-2.7h0c1.2-1.7,2.4-3.4,3.5-5.2a46.5,46.5,0,0,0,3.2-6.3,41.3,41.3,0,0,0,2.4-7,17.2,17.2,0,0,0,.8-3.8,7.6,7.6,0,0,0,.3-2.1c.1-1,.3-1.9.3-2.8v-1a19.8,19.8,0,0,0-.3-3.5,8.6,8.6,0,0,0-1.9-4.7A4.2,4.2,0,0,0,227.9.3a3.3,3.3,0,0,0-1.5-.3h-.6a4.5,4.5,0,0,0-2.5,1.2,10.8,10.8,0,0,0-3,4.6,50.8,50.8,0,0,0-1.7,5.1c-.8,3-1.3,6-1.9,9.1l-.6,3.8c-.1,1.3-.3,2.6-.4,3.9h0c-.1.4-.1.9-.2,1.4a9.9,9.9,0,0,0-.2,1.7h0a12.3,12.3,0,0,0-.2,1.9h0c-.1.5-.1,1.1-.2,1.6h0a12.3,12.3,0,0,0-.2,2h0c-.1.6-.1,1.2-.2,1.9h0l-.3,2.5h0a3.2,3.2,0,0,1-.6,1.8h0a10.5,10.5,0,0,1-4.6,3.4,11.4,11.4,0,0,1-2.5.6h-4.3l.5-.8,1-1.7a15.7,15.7,0,0,0,1.5-2.9,9.4,9.4,0,0,0,1-2.8h0l.6-2.7a16.3,16.3,0,0,0,.3-3.1,5.3,5.3,0,0,0,.1-1.3c0-.6-.1-1.2-.1-1.8h0a14.2,14.2,0,0,0-.4-2h0a9.3,9.3,0,0,0-2.8-4.9,7.4,7.4,0,0,0-2.2-1.4,10.5,10.5,0,0,0-2.4-.6h-3.1a11.4,11.4,0,0,0-4.3,1.7,18.3,18.3,0,0,0-4.6,4.6,37.5,37.5,0,0,0-2.4,4.4c-.3,1-.7,1.9-.9,2.9s-.3,1.8-.5,2.8h0a26.4,26.4,0,0,0-.2,2.8c0,.2-.1.3-.1.5a21.1,21.1,0,0,0,.2,2.5,16.8,16.8,0,0,0,.9,3.2,10,10,0,0,0,2,2.9,7.1,7.1,0,0,0,2.7,1.8,11.7,11.7,0,0,0,3.8.7h.2l1.6-.2a10.4,10.4,0,0,0,4.4-2,2,2,0,0,1,1.3-.4h.3a2.3,2.3,0,0,1,1.1.2h4.2a17.5,17.5,0,0,0,6.6-2.2l.4-.3.3.5a1.7,1.7,0,0,1,.1.7,5.4,5.4,0,0,1-.1.8l-.3,2.6c-.1,1-.3,1.9-.4,2.9h0a6.9,6.9,0,0,0-.2,1.3h0c-.1.9-.3,1.7-.4,2.6h0l-.3,2.5-.6,3.7h0c-.1.4-.1.8-.2,1.3h0c-.1.8-.3,1.6-.4,2.5h0l-.3,2.4c-.1.9-.3,1.7-.4,2.5s-.3,2-.4,3a5.2,5.2,0,0,0-.2,1.1h0v2.3h0a7.6,7.6,0,0,0,.3,2.1h0a8.6,8.6,0,0,0,1.3,2.9,5.5,5.5,0,0,0,2.4,1.8,7.6,7.6,0,0,0,2.6.6h.1l1.2-.2a8,8,0,0,0,2.5-1.1,10.9,10.9,0,0,0,2.4-2.4,11.4,11.4,0,0,0,1.5-3.4,26.8,26.8,0,0,0,.7-2.7,26,26,0,0,0,.3-2.6,21.8,21.8,0,0,0,.1-2.5v-.8l-.3-3.9h0a12.9,12.9,0,0,0-.4-1.9c-.4-1.6-.8-3.2-1.3-4.7a41.6,41.6,0,0,0-1.6-4l-1.1-2.2h0a23.9,23.9,0,0,0-1.2-2.2l-.2-.5-.2-.6h1.2l.9.2h3.2a11.8,11.8,0,0,0,3.1-.5,15.4,15.4,0,0,0,7.6-4.4,16.8,16.8,0,0,0,2.5-2.9l.3-.9h0v-.2A1.1,1.1,0,0,0,236.4,41.5Zm-19.2-5.1c0-.4.1-.8.1-1.1l.3-1.9h0c.1-.5.1-.9.2-1.4h0c0-.6.1-1.2.1-1.8h0l.3-1.7h0c.1-.4.1-.9.2-1.4h0c.2-1.4.3-2.8.5-4.2s.5-3.3.8-5h0c.5-2.2.9-4.5,1.5-6.7s.9-2.9,1.5-4.3a10.1,10.1,0,0,1,2.2-3.7,1.7,1.7,0,0,1,1.2-.5h.2a2.1,2.1,0,0,1,1.1.4l.5.7h0a7.3,7.3,0,0,1,.9,2.3,21.9,21.9,0,0,1,.3,3.6v1l-.3,2.6h0a28.7,28.7,0,0,1-.5,3.1,33.8,33.8,0,0,1-.8,3.4,38.2,38.2,0,0,1-1.8,5.1,49.7,49.7,0,0,1-2.5,5.2c-.9,1.6-1.9,3-2.8,4.5s-1.5,1.9-2.3,2.9l-.8,1.1V36.5ZM195.7,48.1c-.1,0-.1.1-.2.2l-.3.2h0a5.8,5.8,0,0,1-1.8.4h-1.3a7,7,0,0,1-3-.9,5,5,0,0,1-2.1-2.4,10.3,10.3,0,0,1-1.1-3.9c0-.3-.1-.7-.1-1.1v-.2h0c.1-1,.1-2,.3-3h0v-.4a1.6,1.6,0,0,1,.3-.8l.5-.7.3.9a4.9,4.9,0,0,1,.4,1.1h0a15.3,15.3,0,0,0,1.8,3.9,13.3,13.3,0,0,0,2.3,3,10.4,10.4,0,0,0,3.2,2.3h0l.7.5.7.3Zm4.5-3.5-.9,1-.3.3h-.3a12.5,12.5,0,0,1-5.8-3.8,14.8,14.8,0,0,1-3.3-6.9,13.3,13.3,0,0,1-.3-2.8v-.4h0a9.9,9.9,0,0,1,2-5.7,8.3,8.3,0,0,1,2.1-1.7,9.5,9.5,0,0,1,3.5-1.4h1.3a7,7,0,0,1,3.6,1.2,5,5,0,0,1,1.8,2.3h0a9,9,0,0,1,.9,3.3,12.1,12.1,0,0,1,.1,1.9v.8c0,.8-.2,1.5-.2,2.2h0a20,20,0,0,1-.5,2.6,18.5,18.5,0,0,1-1.8,4.4A17.3,17.3,0,0,1,200.2,44.6Zm18.3,13.2a46.5,46.5,0,0,1,2,5.2c.4,1.3.7,2.6,1,4a25.9,25.9,0,0,1,.4,4.8v2.3a14,14,0,0,1-.7,4,11.7,11.7,0,0,1-.6,2,7.9,7.9,0,0,1-1.8,2.9,4.7,4.7,0,0,1-3.2,1.4h-.2a3.6,3.6,0,0,1-2.5-1.3,5.6,5.6,0,0,1-1.3-3.5h0V78.3c.1-.6.1-1.2.2-1.9s.3-1.8.4-2.7h0c.2-.9.3-1.7.4-2.5s.2-1.6.4-2.4h0a25.1,25.1,0,0,1,.4-2.7h0l.3-2.2c.1-1,.3-1.9.4-2.8l.3-2.6h0a17,17,0,0,1,.4-2.2h0a11.1,11.1,0,0,1,.2-1.7h0c.1-.3.1-.6.2-1.1l.2-1.4.7,1.2.9,1.5h0C217.5,55.8,218.1,56.8,218.5,57.8Z" style="fill: #979797;fill-rule: evenodd"/>
+      </g>
+    </g>
+  </g>
+<title>Pinch of Yum logo</title></svg>
+			<div class="mt-8 md:-mt-4 text-center md:text-left">
+				<p class="text-xs mb-0">&copy; 2026 Pinch of Yum. All Rights Reserved.</p>
+				<p class="text-xs mb-0">A Raptive Partner Site.</p>
+			</div>
+		</div>
+	</div>
+	<div>
+		<div class="hidden md:block p-6 text-center bg-purple-500">
+			<p class="mb-2 leading-3 flex space-x-2 justify-center text-white font-arvo uppercase tracking-widest">
+				<span class="footer-signup">signup</span>
+				<span> for Email Updates</span>
+			</p>
+			<p class="mb-4 text-purple-100 italic">Get a Free eCookbook with our top 25 recipes.</p>
+			<script async data-uid="f83b053758" src="https://pinchofyum.ck.page/f83b053758/index.js"></script>
+		</div>
+		<div class="brands pt-10 mt-8 md:mt-0 border-t md:border-0">
+			<h4 class="mb-6 font-arvo not-italic bold tracking-widest text-xs uppercase text-gray-700 text-center">Our Other Brands</h4>
+			<ul class="flex flex-wrap justify-center items-center">
+				<li class="mx-2 md:mx-4"><a href="https://www.foodbloggerpro.com" target="_blank" rel="nofollow noopener">
+				<img
+					class="h-10 md:h-12 w-auto"
+					width="211"
+					height="160"
+					src="https://pinchofyum.com/content/assets/images/food-blogger-pro-logo.png"
+					srcset="https://pinchofyum.com/content/assets/images/food-blogger-pro-logo.png 211w"
+					sizes="(min-width: 780px) 63px, 53px"
+					alt="Food Blogger Pro Logo"
+					loading="lazy"></a></li>
+				<li class="mx-2 md:mx-4"><a href="https://clariti.com" target="_blank" rel="nofollow noopener"><img
+					class="h-6 md:h-8 w-auto"
+					width="300"
+					height="69"
+					src="https://pinchofyum.com/content/assets/images/clariti-logo.svg"
+					srcset="https://pinchofyum.com/content/assets/images/clariti-logo.svg 300w"
+					sizes="(min-width: 780px) 139px, 104px"
+					alt="Clariti Logo"
+					loading="lazy"></a></li>
+			</ul>
+		</div>
+	</div>
+</div>
+<div class="my-10">
+	<p class="text-xs text-center"><a class="mx-2 text-gray-700 hover:text-purple-500" href="https://pinchofyum.com/privacy-policy">Privacy Policy</a><a class="mx-2 text-gray-700 hover:text-purple-500" href="https://pinchofyum.com/terms-of-service">Terms</a></p>
+</div>
+<script async data-uid="3527a72463" src="https://pinchofyum.ck.page/3527a72463/index.js"></script>
+
+		<script>
+	!function(){const e=document.querySelector(".top-nav-cta"),t=document.querySelector(".top-nav-cta-shim"),o=e.querySelector(".top-nav-cta a.top-nav-cta-link"),n=e.querySelector(".top-nav-close"),c=(e,t,o)=>{let n;if(o){const e=new Date;e.setTime(e.getTime()+24*o*60*60*1e3),n="; expires="+e.toGMTString()}else n="";document.cookie=e+"="+t+n+"; SameSite=Strict; path=/"},i=()=>{e.style.display="none",t.style.display="none"};o.addEventListener("click",e=>{e.preventDefault(),c("poy-hide-top-nav-cta",!0),i()}),n.addEventListener("click",()=>{c("poy-hide-top-nav-cta",!0),i()}),(e=>{if(document.cookie.length>0){let t=document.cookie.indexOf(e+"=");if(-1!=t){t=t+e.length+1;let o=document.cookie.indexOf(";",t);return-1==o&&(o=document.cookie.length),unescape(document.cookie.substring(t,o))}}return""})("poy-hide-top-nav-cta")&&i()}();		</script>
+		<script type="speculationrules">
+{"prefetch":[{"source":"document","where":{"and":[{"href_matches":"/*"},{"not":{"href_matches":["/wp-*.php","/wp-admin/*","/uploads/*","/content/*","/content/plugins/*","/content/themes/pinchofyum-2020/*","/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
+</script>
+		<script>
+		(function(){
+			var banner = document.querySelector('.tasty-pins-banner-container');
+			if ( banner && typeof IntersectionObserver !== 'undefined' ) {
+				var observer = new IntersectionObserver(
+					function() {
+						dataLayer.push({
+							'event': 'Tasty Pins Banner Inview',
+							'event_category': 'Tasty Pins Banner',
+						});
+					},
+					{
+						root: null,
+						rootMargin: '0px',
+						threshold: 0.1,
+					}
+				);
+				observer.observe(banner);
+
+				banner.addEventListener('click', function(){
+					dataLayer.push({
+							'event': 'Tasty Pins Banner Click',
+							'event_category': 'Tasty Pins Banner',
+					});
+				});
+			}
+		}())
+		</script>
+		<div class="tasty-pins-hidden-image-container" style="display:none;"><img data-pin-url="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?tp_image_id=116892" alt="Shrimp tacos pin." data-pin-description="The Best Shrimp Tacos with Garlic Cilantro Lime Slaw - ready in about 30 minutes and loaded with flavor and texture. SO YUM! #tacos #tacotuesday #shrimp" data-pin-title="Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw" class="tasty-pins-hidden-image skip-lazy a3-notlazy no-lazyload" data-no-lazy="1" src="https://pinchofyum.com/tachyon/Shrimp-Tacos-Pin-2025-02.jpg?resize=183%2C183" data-pin-media="https://pinchofyum.com/tachyon/Shrimp-Tacos-Pin-2025-02.jpg"></div>
+<div class="tasty-pins-hidden-image-container" style="display:none;"><img data-pin-url="https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw?tp_image_id=116893" alt="Easy shrimp tacos pin." data-pin-description="The Best Shrimp Tacos with Garlic Cilantro Lime Slaw - ready in about 30 minutes and loaded with flavor and texture. SO YUM! #tacos #tacotuesday #shrimp" data-pin-title="Spicy Shrimp Tacos with Garlic Cilantro Lime Slaw" class="tasty-pins-hidden-image skip-lazy a3-notlazy no-lazyload" data-no-lazy="1" src="https://pinchofyum.com/tachyon/Shrimp-Tacos-Pin-2025-01.jpg?resize=183%2C183" data-pin-media="https://pinchofyum.com/tachyon/Shrimp-Tacos-Pin-2025-01.jpg"></div>
+<script type='text/javascript' src='//assets.pinterest.com/js/pinit.js' data-pin-hover='true'></script>
+<script type="text/html" id="tmpl-tasty-pins-follow-box">
+<div class="tasty-pins-follow-box-wrapper">
+	<div class="tasty-pins-follow-box tasty-shadow-lg">
+		<div class="tasty-pins-follow-box-header" style="background-image: url(https://pinchofyum.com/content/uploads/Banner-Image.png);">
+			<button type="button" aria-label="close" class="tasty-pins-follow-box-close">
+				<svg width="12" height="18" viewBox="0 0 12 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<g clip-path="url(#clip0)">
+						<path d="M3.72545 9L0.313977 5.48191C-0.10466 5.0502 -0.10466 4.35023 0.313977 3.91816L1.07216 3.13629C1.4908 2.70457 2.16954 2.70457 2.58852 3.13629L6 6.65437L9.41148 3.13629C9.83011 2.70457 10.5089 2.70457 10.9278 3.13629L11.686 3.91816C12.1047 4.34988 12.1047 5.04984 11.686 5.48191L8.27455 9L11.686 12.5181C12.1047 12.9498 12.1047 13.6498 11.686 14.0818L10.9278 14.8637C10.5092 15.2954 9.83011 15.2954 9.41148 14.8637L6 11.3456L2.58852 14.8637C2.16989 15.2954 1.4908 15.2954 1.07216 14.8637L0.313977 14.0818C-0.10466 13.6501 -0.10466 12.9502 0.313977 12.5181L3.72545 9Z" fill="#515251"/>
+					</g>
+					<defs>
+					<clipPath id="clip0">
+						<rect width="12" height="18" fill="white" transform="matrix(-1 0 0 1 12 0)"/>
+					</clipPath>
+					</defs>
+				</svg>
+			</button>
+			<div class="tasty-pins-follow-box-logo" style="background-image: url(https://pinchofyum.com/content/uploads/poy-logo-stacked@2x-1.png); background-color: #734060;"></div>
+		</div>
+		<div class="tasty-pins-follow-box-inner">
+			<h3>Pinch of Yum</h3>
+			<p>A food blog with simple, tasty, and (mostly) healthy recipes.</p>
+			<a class="tasty-pins-follow-box-button" href="https://www.pinterest.com/pinchofyum/_created/" style="background-color: #734060;color: #FFF;" target="_blank">
+				Follow on
+				<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+					<path d="M23.25 12C23.25 5.57812 18.0469 0.375 11.625 0.375C5.20312 0.375 0 5.57812 0 12C0 16.9688 3.04688 21.1406 7.35938 22.8281C7.26562 21.9375 7.17188 20.5312 7.40625 19.5C7.64062 18.6094 8.76562 13.7344 8.76562 13.7344C8.76562 13.7344 8.4375 13.0312 8.4375 12C8.4375 10.4062 9.375 9.1875 10.5469 9.1875C11.5312 9.1875 12 9.9375 12 10.8281C12 11.8125 11.3438 13.3125 11.0156 14.7188C10.7812 15.8438 11.625 16.7812 12.75 16.7812C14.8125 16.7812 16.4062 14.625 16.4062 11.4844C16.4062 8.67188 14.3906 6.75 11.5781 6.75C8.25 6.75 6.32812 9.23438 6.32812 11.7656C6.32812 12.7969 6.70312 13.875 7.17188 14.4375C7.26562 14.5312 7.26562 14.6719 7.26562 14.7656C7.17188 15.1406 6.9375 15.9375 6.9375 16.0781C6.89062 16.3125 6.75 16.3594 6.51562 16.2656C5.0625 15.5625 4.17188 13.4531 4.17188 11.7188C4.17188 8.0625 6.84375 4.6875 11.8594 4.6875C15.8906 4.6875 19.0312 7.59375 19.0312 11.4375C19.0312 15.4219 16.5 18.6562 12.9844 18.6562C11.8125 18.6562 10.6875 18.0469 10.3125 17.2969C10.3125 17.2969 9.75 19.5469 9.60938 20.0625C9.32812 21.0938 8.625 22.3594 8.15625 23.1094C9.23438 23.4844 10.4062 23.625 11.625 23.625C18.0469 23.625 23.25 18.4219 23.25 12Z" fill="white"/>
+				</svg>
+			</a>
+		</div>
+	</div>
+	<div class="tasty-pins-follow-box-affiliate">
+		<a target="_blank" href="https://www.wptasty.com/tasty-pins">powered by
+			<svg xmlns="http://www.w3.org/2000/svg" width="93" height="24" viewBox="0 0 428.22 110.38"><defs><style>.cls-3{stroke-miterlimit:10;stroke-width:3.06px;}</style></defs><title>Asset 7</title><g id="Layer_2" data-name="Layer 2"><g id="Layer_1-2" data-name="Layer 1"><path fill="currentColor" d="M5.32,47.49c-2.22-.22-4.1-.44-4.1-2.88,0-3.44,2.44-6.54,7-6.66.11-2.33.22-4.1.67-8.21C9.87,20,15.86,13,23.4,13c5.1,0,7.43,1.78,7.43,6.54,0,3.44-1.33,6.1-7.21,17.86a77.68,77.68,0,0,0,9.54-.78,6.14,6.14,0,0,1,2.11,4.66c0,4.21-2.77,7.43-6.43,7.43a44,44,0,0,1-8.1-.67c-3,12.2-3.88,18.41-3.88,20.08,0,2.66.67,3.88,3,3.88,4.55,0,12.2-5.32,19.74-16C41.7,56,44,57.58,44,59.8c0,6.54-17,26.4-29.73,26.4C5.77,86.2,0,81.76,0,71.56,0,68.34,1.11,61.58,5.32,47.49Z"/><path fill="currentColor" d="M41.48,84.32c-6.32,0-11-5.21-11-15.31C30.5,52.37,44.25,35,55.35,35c1.55,0,2.33.22,2.88.78l.33-6.43a5.1,5.1,0,0,1,3.88-1.44c7.54,0,11.65,5.1,11.65,9a29.63,29.63,0,0,1-1.22,7.32c-3.88,14-5.32,21-5.32,23.85,0,2.22.44,2.55,1.33,2.55,2.22,0,8-4.21,15.08-14.2,2.33,0,4.1,1.44,4.1,3.44,0,7.21-18.41,25.07-26.4,25.07-4.88,0-8-2-8-9.1A33.38,33.38,0,0,1,54,71.45C50.47,81.54,45.36,84.32,41.48,84.32ZM57.67,42.94C52.13,46.49,46.8,55.7,46.8,64.24c0,4.1,1.33,4.55,2.88,4.55s3.11-1.11,4.44-2.77Z"/><path fill="currentColor" d="M91.5,60.25c0,2.33-1,4-2.88,6.1.89,4.88,4.66,8.21,7.21,8.21A2.27,2.27,0,0,0,98.16,72c0-5.66-6.43-19.08-6.43-26,0-9.32,7.54-15.75,17.64-15.75,6.43,0,10.2,2.77,10.2,8.1a8.87,8.87,0,0,1-2.33,6,15.37,15.37,0,0,0-5.88-1.33c-2.33,0-3.55.67-3.55,2.66,0,5,6.32,14.2,6.32,22.29,0,13.42-11.42,18.63-21.41,18.63-8.65,0-15.42-5.88-15.42-16.86,0-6.54,1.77-17.3,7.21-17.3C88.39,52.48,91.5,57.47,91.5,60.25Z"/><path fill="currentColor" d="M126.77,47.49c-2.22-.22-4.1-.44-4.1-2.88,0-3.44,2.44-6.54,7-6.66.11-2.33.22-4.1.67-8.21,1-9.76,7-16.75,14.53-16.75,5.1,0,7.43,1.78,7.43,6.54,0,3.44-1.33,6.1-7.21,17.86a77.68,77.68,0,0,0,9.54-.78,6.14,6.14,0,0,1,2.11,4.66c0,4.21-2.77,7.43-6.43,7.43a44,44,0,0,1-8.1-.67c-3,12.2-3.88,18.41-3.88,20.08,0,2.66.67,3.88,3,3.88,4.55,0,12.2-5.32,19.74-16,2.11,0,4.44,1.55,4.44,3.77,0,6.54-17,26.4-29.73,26.4-8.54,0-14.31-4.44-14.31-14.64C121.45,68.34,122.55,61.58,126.77,47.49Z"/><path fill="currentColor" d="M163,110.38c-7.76,0-14-4.88-14-12.64,0-5.43,3.11-10.43,8.1-10.43a13.2,13.2,0,0,1,2.88.55c.78,6.65,2.77,10.54,4.55,10.54s2.55-1.33,2.55-4.21c0-3.55-2.44-13.64-4.88-22.52-2.11-7.54-2.55-8.87-3.11-11.54a40.71,40.71,0,0,1-.78-8.32c0-9.76,7.76-18.52,16.08-18.52,4.21,0,6.32,1.55,6.32,4.88s-2.55,8-5.21,10.87c0,4.33.55,8.21,2.77,17.19,7.54-9.65,8.54-12.31,8.54-17.41,0-2.33-2.11-8.32-3.44-10.65.78-3.66,4.55-5.54,7.32-5.54,6.21,0,9.54,6.32,9.54,13,0,7-5.21,19.08-19,31.83a99,99,0,0,1,.55,10.87C181.89,103.06,173.13,110.38,163,110.38Z"/><path fill="currentColor" d="M259.09,35.73q.79-.1,1.86-.21t2.26-.18l2.36-.13q1.18-.05,2.28-.05a25.22,25.22,0,0,1,5.48.58,12.29,12.29,0,0,1,4.57,2A10,10,0,0,1,281,41.48a13.16,13.16,0,0,1,1.16,5.85A13.5,13.5,0,0,1,281,53.44a10.69,10.69,0,0,1-3.25,3.91,12.61,12.61,0,0,1-4.59,2.07,22.9,22.9,0,0,1-5.25.6l-1.76,0q-.76,0-1.65-.13V73.52a21.7,21.7,0,0,1-2.68.16l-1.34,0a10.66,10.66,0,0,1-1.34-.13Zm5.35,19.47q.84.11,1.47.16t1.84.05a15.38,15.38,0,0,0,3.23-.34,7.63,7.63,0,0,0,2.86-1.23,6.35,6.35,0,0,0,2-2.44,9.13,9.13,0,0,0,.76-4,8.88,8.88,0,0,0-.66-3.62,6,6,0,0,0-1.81-2.36,7,7,0,0,0-2.78-1.26,16,16,0,0,0-3.52-.37,32.55,32.55,0,0,0-3.41.16Z"/><path fill="currentColor" d="M298.25,35.78q.63-.1,1.31-.16c.45,0,.91-.05,1.36-.05s.91,0,1.36.05.89.09,1.31.16V73.52q-.63.1-1.29.16c-.44,0-.9.05-1.39.05s-.92,0-1.39-.05a12.53,12.53,0,0,1-1.29-.16Z"/><path fill="currentColor" d="M322.28,35.78q.58-.1,1.23-.16c.44,0,.85-.05,1.23-.05s.79,0,1.23.05.85.09,1.23.16l16.43,28.34V35.78q.63-.1,1.31-.16c.45,0,.91-.05,1.36-.05s.79,0,1.21.05.82.09,1.21.16V73.52c-.39.07-.8.12-1.23.16s-.85.05-1.23.05-.8,0-1.23-.05-.85-.09-1.23-.16L327.32,45.34V73.52c-.39.07-.8.12-1.23.16s-.87.05-1.29.05-.9,0-1.34-.05a10.38,10.38,0,0,1-1.18-.16Z"/><path fill="currentColor" d="M366.47,67.8a36.56,36.56,0,0,0,3.62,1.1,19.36,19.36,0,0,0,4.62.47q4.3,0,6.43-1.76a5.84,5.84,0,0,0,2.13-4.75,6.44,6.44,0,0,0-.45-2.52,4.86,4.86,0,0,0-1.34-1.81,10,10,0,0,0-2.23-1.39q-1.34-.63-3.12-1.36l-3-1.21a20.46,20.46,0,0,1-2.78-1.39,8.6,8.6,0,0,1-2.18-1.86,8.43,8.43,0,0,1-1.44-2.54,10.08,10.08,0,0,1-.52-3.44,9.19,9.19,0,0,1,3.25-7.48q3.25-2.7,9.13-2.7a26.14,26.14,0,0,1,4.78.42,25.27,25.27,0,0,1,4,1A16.38,16.38,0,0,1,386.2,41a26.16,26.16,0,0,0-3.28-.94,19.34,19.34,0,0,0-4.22-.42A8.36,8.36,0,0,0,373.61,41a4.7,4.7,0,0,0-1.78,4,4.23,4.23,0,0,0,.45,2,5.22,5.22,0,0,0,1.18,1.52,8.48,8.48,0,0,0,1.73,1.18,19,19,0,0,0,2.1.95l2.94,1.15a31.29,31.29,0,0,1,3.73,1.76,11.56,11.56,0,0,1,2.78,2.15,8.35,8.35,0,0,1,1.76,2.91,11.67,11.67,0,0,1,.6,3.94A10.53,10.53,0,0,1,385.36,71q-3.73,3.12-10.44,3.12-1.63,0-2.94-.11a23.89,23.89,0,0,1-2.44-.31,21,21,0,0,1-2.18-.52q-1.05-.31-2.15-.68a11.71,11.71,0,0,1,.47-2.36Q366,69,366.47,67.8Z"/><path fill="none" stroke="currentColor" d="M403.07,1.53A5.33,5.33,0,0,1,406.44,3l18.88,20a5.82,5.82,0,0,1,1.37,3.45v77.94a2,2,0,0,1-2,2H223.63a2,2,0,0,1-2-2V3.53a2,2,0,0,1,2-2Z"/></g></g></svg>
+		</a>
+	</div>
+</div>
+</script>
+<script type='text/javascript' src='https://pinchofyum.com/content/plugins/tasty-pins/assets/js/follow-box.js?v=1758147406'></script>
+<style style="display: none !important;">.tasty-pins-follow-box{border-radius:10px;height:400px;overflow:hidden;width:400px}.tasty-pins-follow-box .tasty-pins-follow-box-header{background-position:50%;background-repeat:no-repeat;background-size:cover;height:143px;position:relative}.tasty-pins-follow-box .tasty-pins-follow-box-header:before{background-color:hsla(0,0%,77%,.5);bottom:0;content:"";display:block;left:0;position:absolute;right:0;top:0}.tasty-pins-follow-box .tasty-pins-follow-box-logo{background-origin:content-box;background-position:50%;background-repeat:no-repeat;background-size:contain;border:3px solid #fff;border-radius:9999px;bottom:0;height:120px;left:50%;padding:15px;position:absolute;transform:translate(-50%,50%);width:120px}.tasty-pins-follow-box .tasty-pins-follow-box-inner{padding:60px 20px 10px;text-align:center}.tasty-pins-follow-box .tasty-pins-follow-box-inner h3{font-size:24px;margin:.25em 0}.tasty-pins-follow-box .tasty-pins-follow-box-inner p{font-size:18px;line-height:1.5;margin:0 0 1em}.tasty-pins-follow-box .tasty-pins-follow-box-button{align-items:center;border-radius:10px;display:inline-flex;font-size:16px;font-weight:700;letter-spacing:1px;padding:10px 20px;text-decoration:none;text-transform:uppercase}.tasty-pins-follow-box .tasty-pins-follow-box-button:hover{opacity:.8}.tasty-pins-follow-box-container{background:rgba(0,0,0,.75);bottom:0;left:0;position:fixed;right:0;top:0;z-index:10000000}.tasty-pins-follow-box-container .tasty-pins-follow-box-wrapper{left:50%;position:absolute;top:50%;transform:translate(-50%,-50%)}.tasty-pins-follow-box-container .tasty-pins-follow-box{background-color:#fff}.tasty-pins-follow-box-button svg{margin-left:8px}.tasty-pins-settings-preview-container .tasty-pins-follow-box .tasty-pins-follow-box-logo{height:86px;width:86px}.tasty-pins-settings-preview-container .tasty-pins-follow-box .tasty-pins-follow-box-inner{padding:72px 40px 10px}.tasty-pins-follow-box-close{align-items:center;background:hsla(0,0%,100%,.8);border:2px solid #fff;border-radius:50%;display:flex;filter:drop-shadow(2px 2px 2px rgba(0,0,0,.3));height:28px;justify-content:center;padding:0;position:absolute;right:6px;top:6px;width:28px}.tasty-pins-follow-box-affiliate{width:400px}.tasty-pins-follow-box-affiliate a{align-items:center;color:#dfdfdf;display:flex;font-size:1.125em;justify-content:center;margin-top:10px;text-decoration:none}.tasty-pins-follow-box-affiliate a[href="#"]{display:none}.tasty-pins-follow-box-affiliate svg{margin-left:7px}
+</style>		<script>
+		(function(){
+			document.addEventListener('tasty-pins-open-follow-box', function( event ) {
+				document.querySelector( '.tasty-pins-follow-box-affiliate' )?.remove();
+				dataLayer.push( {
+					'event': 'Tasty Pins Follow Box Open',
+					'event_category': 'Tasty Pins Follow Box',
+					'event_label': event.detail.label,
+				});
+				document.querySelector('.tasty-pins-follow-box-container .tasty-pins-follow-box-affiliate a').addEventListener('click', function() {
+					dataLayer.push({
+						'event': 'Tasty Pins Follow Box Affiliate Click',
+						'event_category': 'Tasty Pins Follow Box',
+						'event_label': 'Tasty Pins Follow Box Affiliate Click',
+					});
+				});
+			});
+			document.addEventListener('tasty-pins-close-follow-box', function( event ) {
+				dataLayer.push({
+					'event': 'Tasty Pins Follow Box Close',
+					'event_category': 'Tasty Pins Follow Box',
+					'event_label': event.detail.label,
+				});
+			});
+		}())
+		</script>
+		<script id="convertkit-js-js-extra">
+var convertkit_broadcasts = {"ajax_url":"https://pinchofyum.com/wp-json/kit/v1/broadcasts","debug":""};
+var convertkit = {"ajaxurl":"https://pinchofyum.com/wp-json/kit/v1/subscriber/store-email-as-id-in-cookie","debug":"","nonce":"9411c1161e","subscriber_id":"0"};
+//# sourceURL=convertkit-js-js-extra
+</script>
+<script id="convertkit-js-js" src="https://pinchofyum.com/content/plugins/convertkit/resources/frontend/js/dist/frontend.min.js?ver=3.3.5"></script>
+<script id="convertkit-commerce-js" src="https://pinchofyum.kit.com/commerce.js?ver=7.0.2"></script>
+<script async data-wp-strategy="async" fetchpriority="low" id="comment-reply-js" src="https://pinchofyum.com/wp-includes/js/comment-reply.min.js?ver=7.0.2"></script>
+<script id="rum-collector-js-extra">
+var rumCollectorData = {"waitOnLoad":"3000","sampleRate":"0.1","endpoint":"https://rum-service-663337444414.us-west1.run.app/collect"};
+//# sourceURL=rum-collector-js-extra
+</script>
+<script id="rum-collector-js" src="https://pinchofyum.com/content/plugins/beaconwp//build/index.js?ver=1768937456"></script>
+<script id="altis-consent-api-js-extra">
+var consent_api = {"consent_type":"optin","waitfor_consent_hook":"","cookie_expiration":"30","cookie_prefix":"_altis_consent"};
+//# sourceURL=altis-consent-api-js-extra
+</script>
+<script id="altis-consent-api-js" src="https://pinchofyum.com/vendor/altis/consent-api/src/wp-consent-api.min.js?ver=7.0.2"></script>
+<script id="tasty-recipes-cook-mode-js" src="https://pinchofyum.com/content/plugins/tasty-recipes/assets/js/cook-mode.js?ver=4.0.4"></script>
+<script id="quicktags-js-extra">
+var quicktagsL10n = {"closeAllOpenTags":"Close all open tags","closeTags":"close tags","enterURL":"Enter the URL","enterImageURL":"Enter the URL of the image","enterImageDescription":"Enter a description of the image","textdirection":"text direction","toggleTextdirection":"Toggle Editor Text Direction","dfw":"Distraction-free writing mode","strong":"Bold","strongClose":"Close bold tag","em":"Italic","emClose":"Close italic tag","link":"Insert link","blockquote":"Blockquote","blockquoteClose":"Close blockquote tag","del":"Deleted text (strikethrough)","delClose":"Close deleted text tag","ins":"Inserted text","insClose":"Close inserted text tag","image":"Insert image","ul":"Bulleted list","ulClose":"Close bulleted list tag","ol":"Numbered list","olClose":"Close numbered list tag","li":"List item","liClose":"Close list item tag","code":"Code","codeClose":"Close code tag","more":"Insert Read More tag"};
+//# sourceURL=quicktags-js-extra
+</script>
+<script id="quicktags-js" src="https://pinchofyum.com/wp-includes/js/quicktags.min.js?ver=7.0.2"></script>
+<script id="convertkit-admin-quicktags-js-extra">
+var convertkit_quicktags = {"broadcasts":{"title":"Kit Broadcasts","icon":"resources/backend/images/block-icon-broadcasts.svg","attributes":{"display_grid":{"type":"boolean","default":false},"display_order":{"type":"string","default":"date-broadcast"},"date_format":{"type":"string","default":"F j, Y"},"display_image":{"type":"boolean","default":false},"display_description":{"type":"boolean","default":false},"display_read_more":{"type":"boolean","default":false},"read_more_label":{"type":"string","default":"Read more"},"limit":{"type":"number","default":10},"page":{"type":"number","default":1},"paginate":{"type":"boolean","default":false},"paginate_label_prev":{"type":"string","default":"Previous"},"paginate_label_next":{"type":"string","default":"Next"},"style":{"type":"object"},"backgroundColor":{"type":"string"},"textColor":{"type":"string"},"fontSize":{"type":"string"},"is_gutenberg_example":{"type":"boolean","default":false}},"render_callback":[{},"render"]},"content":{"title":"Kit Custom Content","icon":"resources/backend/images/block-icon-content.svg","attributes":{"tag":{"type":"string"}},"render_callback":[{},"render"]},"formtrigger":{"title":"Kit Form Trigger","icon":"resources/backend/images/block-icon-formtrigger.svg","attributes":{"form":{"type":"string","default":""},"text":{"type":"string","default":"Subscribe"},"style":{"type":"object"},"backgroundColor":{"type":"string"},"textColor":{"type":"string"},"fontSize":{"type":"string"},"is_gutenberg_example":{"type":"boolean","default":false}},"render_callback":[{},"render"]},"form":{"title":"Kit Form","icon":"resources/backend/images/block-icon-form.svg","attributes":{"form":{"type":"string"},"align":{"type":"string"},"style":{"type":"object"},"backgroundColor":{"type":"string"},"is_gutenberg_example":{"type":"boolean","default":false}},"render_callback":[{},"render"]},"product":{"title":"Kit Product","icon":"resources/backend/images/block-icon-product.svg","attributes":{"product":{"type":"string","default":""},"text":{"type":"string","default":"Buy my product"},"discount_code":{"type":"string","default":""},"checkout":{"type":"boolean","default":false},"disable_modal_on_mobile":{"type":"boolean","default":false},"style":{"type":"object"},"backgroundColor":{"type":"string"},"textColor":{"type":"string"},"fontSize":{"type":"string"},"is_gutenberg_example":{"type":"boolean","default":false}},"render_callback":[{},"render"]}};
+var convertkit_admin_tinymce = {"ajaxurl":"https://pinchofyum.com/wp-json/kit/v1/editor/tinymce/modal","nonce":"9411c1161e"};
+//# sourceURL=convertkit-admin-quicktags-js-extra
+</script>
+<script id="convertkit-admin-quicktags-js" src="https://pinchofyum.com/content/plugins/convertkit/resources/backend/js/quicktags.js?ver=3.3.5"></script>
+<script id="tasty-recipes-nutrifox-resize-js" src="https://pinchofyum.com/content/plugins/tasty-recipes/inc/libs/tasty-recipes-lite/assets/js/nutrifox-resize.js?ver=1783444362"></script>
+<script id="tasty-recipes-js-before">
+window.trCommon={"ajaxurl":"https:\/\/pinchofyum.com\/wp-admin\/admin-ajax.php","ratingNonce":"","postId":23546};
+//# sourceURL=tasty-recipes-js-before
+</script>
+<script id="tasty-recipes-js" src="https://pinchofyum.com/content/plugins/tasty-recipes/inc/libs/tasty-recipes-lite/assets/dist/recipe-js.build.js?ver=1.2.6"></script>
+<script id="tasty-recipes-fraction-js" src="https://pinchofyum.com/content/plugins/tasty-recipes/assets/js/frac.js?ver=4.0.4"></script>
+<script id="tasty-recipes-convert-buttons-js" src="https://pinchofyum.com/content/plugins/tasty-recipes/assets/js/convert-buttons.js?ver=4.0.4"></script>
+<script id="tasty-recipes-scale-buttons-js" src="https://pinchofyum.com/content/plugins/tasty-recipes/assets/js/scale-buttons.js?ver=4.0.4"></script>
+<script defer id="akismet-frontend-js" src="https://pinchofyum.com/content/plugins/akismet/_inc/akismet-frontend.js?ver=1774230728"></script>
+		<script type="text/template" id="tmpl-convertkit-quicktags-modal">
+			<div id="convertkit-quicktags-modal">
+				<div class="media-frame-title"><h1></h1></div>
+				<div class="media-frame-content"></div>
+				<div class="media-frame-toolbar">
+					<div class="media-toolbar">
+						<div class="media-toolbar-secondary">
+							<button type="button" class="button button-large cancel">Cancel</button>
+						</div>
+						<div class="media-toolbar-primary">
+							<button type="button" class="button button-primary button-large">Insert</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</script>
+		<script data-no-optimize='1' data-cfasync='false' id='adblock-detection-cda6a3e'>(function(){(function(e){if(e.cookie.indexOf(`__adblocker`)===-1){let t=new XMLHttpRequest;t.open(`GET`,`https://ads.adthrive.com/abd/abd.js`,!0),t.onreadystatechange=function(){if(t.readyState===4)if(t.status===200){let n=e.createElement(`script`);n.innerHTML=t.responseText,e.getElementsByTagName(`head`)[0].appendChild(n)}else{let t=new Date;t.setTime(t.getTime()+300*1e3),e.cookie=`__adblocker=true; expires=`+t.toUTCString()+`; path=/`}},t.send()}})(document)})();</script><script data-no-optimize='1' data-cfasync='false' data-abr-mode='light' id='adblock-recovery-cda6a3e'>(function(){(function(){var e=document.currentScript,t=e&&e.dataset&&e.dataset.abrMode?e.dataset.abrMode:`light`;function n(){var e=document.cookie.match(`(^|[^;]+)\\s*__adblocker\\s*=\\s*([^;]+)`);return e&&e.pop()}function r(){var e=document.createElement(`script`);e.async=!0,e.id=`Tqgkgu`,e.setAttribute(`data-sdk`,`l/1.1.15`),e.setAttribute(`data-cfasync`,`false`),e.src=`https://html-load.com/loader.min.js`,e.charset=`UTF-8`,e.setAttribute(`data`,`kfpvgbrkab9r4a5rkrqrkwagrw6rzrv8rxag0asrka5abaoagrxa5srxrxabasrkrvabaoaxrx0asrkabrxfaba1raa5a5asrkr9wa1agrw6rzr9rkaia8`),e.setAttribute(`onload`,`(async()=>{let e='html-'+'load.com';const t=window,a=document,r=e=>new Promise((t=>{const a=.1*e,r=e+Math.floor(2*Math.random()*a)-a;setTimeout(t,r)})),o=t.addEventListener.bind(t),n=t.postMessage.bind(t),s=btoa,i='message',l=location,c=Math.random;try{const t=()=>new Promise(((e,t)=>{let a=c().toString(),r=c().toString();o(i,(e=>e.data===a&&n(r,'*'))),o(i,(t=>t.data===r&&e())),n(a,'*'),setTimeout((()=>{t(Error('Timeout'))}),1231)})),a=async()=>{try{let e=!1;const a=c().toString();if(o(i,(t=>{t.data===a+'_as_res'&&(e=!0)})),n(a+'_as_req','*'),await t(),await r(500),e)return!0}catch(e){}return!1},s=[100,500,1e3];for(let o=0;o<=s.length&&!await a();o++){if(o===s.length-1)throw'Failed to load website properly since '+e+' is tainted. Please allow '+e;await r(s[o])}}catch(d){try{const e=a.querySelector('script#Tqgkgu').getAttribute('onerror');t[s(l.hostname+'_show_bfa')]=d,await new Promise(((t,r)=>{o('message',(e=>{'as_modal_loaded'===e.data&&t()})),setTimeout((()=>r(d)),3e3);const n=a.createElement('script');n.innerText=e,a.head.appendChild(n),n.remove()}))}catch(m){(t=>{const a='https://report.error-report.com/modal';try{confirm('There was a problem loading the page. Please click OK to learn more.')?l.href=a+'?url='+s(l.href)+'&error='+s(t)+'&domain='+e:l.reload()}catch(d){location.href=a+'?eventId=&error=Vml0YWwgQVBJIGJsb2NrZWQ%3D&domain='+e}})(d)}}})();`),e.setAttribute(`onerror`,`(async()=>{const e=window,t=document;let r=JSON.parse(atob('WyJodG1sLWxvYWQuY29tIiwiZmIuaHRtbC1sb2FkLmNvbSIsImQzN2o4cGZ4dTJpb2dpLmNsb3VkZnJvbnQubmV0IiwiY29udGVudC1sb2FkZXIuY29tIiwiZmIuY29udGVudC1sb2FkZXIuY29tIl0=')),o=r[0];const a='addEventListener',n='setAttribute',s='getAttribute',i=location,l=clearInterval,c='as_retry',d=i.hostname,h=e.addEventListener.bind(e),m=btoa,u='https://report.error-report.com/modal',b=e=>{try{confirm('There was a problem loading the page. Please click OK to learn more.')?i.href=u+'?url='+m(i.href)+'&error='+m(e)+'&domain='+o:i.reload()}catch(t){location.href=u+'?eventId=&error=Vml0YWwgQVBJIGJsb2NrZWQ%3D&domain='+o}},p=async e=>{try{localStorage.setItem(i.host+'_fa_'+m('last_bfa_at'),Date.now().toString())}catch(p){}setInterval((()=>t.querySelectorAll('link,style').forEach((e=>e.remove()))),100);const r=await fetch('https://error-report.com/report?type=loader_light&url='+m(i.href)+'&error='+m(e),{method:'POST'}).then((e=>e.text())),a=new Promise((e=>{h('message',(t=>{'as_modal_loaded'===t.data&&e()}))}));let s=t.createElement('iframe');s.src=u+'?url='+m(i.href)+'&eventId='+r+'&error='+m(e)+'&domain='+o,s[n]('style','width:100vw;height:100vh;z-index:2147483647;position:fixed;left:0;top:0;');const c=e=>{'close-error-report'===e.data&&(s.remove(),removeEventListener('message',c))};h('message',c),t.body.appendChild(s);const d=setInterval((()=>{if(!t.contains(s))return l(d);(()=>{const e=s.getBoundingClientRect();return'none'!==getComputedStyle(s).display&&0!==e.width&&0!==e.height})()||(l(d),b(e))}),1e3);await new Promise(((t,r)=>{a.then(t),setTimeout((()=>r(e)),3e3)}))},f=m(d+'_show_bfa');if(e[f])p(e[f]);else try{if(void 0===e[c]&&(e[c]=0),e[c]>=r.length)throw'Failed to load website properly since '+o+' is blocked. Please allow '+o;if((()=>{const t=e=>{let t=0;for(let r=0,o=e.length;o>r;r++)t=(t<<5)-t+e.charCodeAt(r),t|=0;return t},r=Date.now(),o=r-r%864e5,a=o-864e5,n=o+864e5,s='loader-check',i='as_'+t(s+'_'+o),l='as_'+t(s+'_'+a),c='as_'+t(s+'_'+n);return i!==l&&i!==c&&l!==c&&!!(e[i]||e[l]||e[c])})())return;const i=t.querySelector('#Tqgkgu'),l=t.createElement('script');for(let e=0;e<i.attributes.length;e++)l[n](i.attributes[e].name,i.attributes[e].value);const h=m(d+'_onload');e[h]&&l[a]('load',e[h]);const u=m(d+'_onerror');e[u]&&l[a]('error',e[u]);const b=new e.URL(i[s]('src'));b.host=r[e[c]++],l[n]('src',b.href),i[n]('id',i[s]('id')+'_'),i.parentNode.insertBefore(l,i),i.remove()}catch(w){try{await p(w)}catch(w){b(w)}}})();`),document.head.appendChild(e);var t=document.createElement(`script`);t.setAttribute(`data-cfasync`,`false`),t.setAttribute(`nowprocket`,``),t.textContent=`(async()=>{function t(t) { const e = t.length; let o = ''; for (let r = 0; e > r; r++) { o += t[2939 * (r + 20) % e] } return o }const e=window,o=t('Elementcreate'),r=t('pielnddaCph'),n=t('erdeLtedvtsnaEni'),c=t('tAtesetubirt'),a=document,i=a.head,s=a[o].bind(a),d=i[r].bind(i),l=location,m=l.hostname,h=btoa;e[n].bind(e);let u=t('oad.comhtml-l');(async()=>{try{const n=a.querySelector(t('#Tqgkguscript'));if(!n)throw t('onnaC dnif t')+u+t('i.cp rts');const i=n.getAttribute(t('nororre')),f=n.getAttribute(t('aolnod')),p=await new Promise((o=>{const r=t('x')+Math.floor(1e6*Math.random());e[r]=()=>o(!0);const n=s(t('pircst'));n.src=t(':atad;'),n[c](t('nororre'),t('iw.wodn')+r+t('()')),d(n),setTimeout((()=>{o(!1), n.remove()}),251)}));if(p)return;function o(){const e=s(t('pircst'));e.innerText=i,d(e),e.remove()}const b=h(m+t('o_daoln')),w=h(m+t('rrnr_eoo'));e[b]=function(){const e=s(t('pircst'));e.innerText=f,d(e),e.remove()},e[w]=o,o()}catch(r){(e => { const o = t('ro/treeol/t-.dsoormterpmh/.rca:rrtopp'); try { const r = t('cleopr   eges.eke aremtc. m Ta apdo ool t ahrOsaibwr iPhl enKegnlael'); confirm(r) ? l.href = o + t('?=lru') + h(l.href) + t('e&=rorr') + h(e) + t('a=oi&mnd') + u : l.reload() } catch (r) { location.href = o + t('J%ndVVNdvrYGQiI=Q2&ee0IWatrgbD?&lJZmnows3==mBroerW') + u } })(r)}})()})();`,document.head.appendChild(t)}function i(){var e=document.createElement(`script`);e.setAttribute(`data-cfasync`,`false`),e.dataset.domain=`html-load.cc`,e.textContent=`(function(){function p(){const X=['W64nwmoJW7hdK8kjW7BcUMu','W60xWQxcMW','WRabWRBcHq','W7fJWRm/','xmoZvmkR','W6BdLSo8Aq','W59mcrC','qdZdImop','WQuUq0S','W5WQW4FdLW','pCkHygO','WPHguSoy','W6tcGaHl','qN/dRSkS','W4b6WO0','W4fucuW','W4tdNSoVeq','W5pcISoUwq','aa0ywq','amkvhuu','mZhcMmkm','WOm3WOKv','WRVcH8kkwmoJBCoXW5/cMq','x8kPW57dTG','mSo9se8','EIvxoW','W51ihf8','WRexWQFcJG','g3BdPCox','cWSCrq','W6L+WQ1G','mCkIBMS','W5WIW4JdISkVW5BdRCkPnCku','W7rtW7JcNG','WORcSWu','W5hdR8o0W4y','nSkKW6NdVW','jqBcUXO','ax7cMa','W6iex8oZjCk9W45Utq','WPPqv8oz','W6zsWQhcRa','W4JdHmk1bG','sSo9q8kS','kItcN1O','W4tdN8kSfW','WQ5Aa8k0','W5mgdvW','kYhcVIK','fmozW7a/','W6n9WQvR','W7b1WQ5X','WRizWPW','hSkGW43dKa','W6OgvSoJW4hdUSkWW4dcGKa','aHSvBa','WP8SWOGi','rmkkqH3cM23cPSoHW7xcOq','WO7cI0ZcKa','W4ZdH8kHW4e','WRldMLuoWRqlFSkYr8o+W4pdGG','jH3cRmkA','A8k6c2FdS2tdSuldSW','oY3cGWe','W6FdNmoqCq','c2dcLwy','v2ubWOC','o8oju8og','W4xdLSkYwq','WRfEW6NdHG','W78yW6BcRa','nmovW60S','WOhcQSkWWPPqB2tdUaPvC8o/','WO3dG8kPhW','W47dKCk2','a8kTW4tcSa','WOvmaSop','dwdcJNK','WRnnW69a','sNFdRG','WOrwwCow','WRewWQu','o1BcPCkx','tCo7DmkP','WQObWQFcJq','jWVdSLG','z8o0mem0lYJcT8kq','W4hcTbpdGG','a8kNW7ZdKq','pcxcJCkr','xCkWuSkM','WPGsrq4qWQz2s8oPW6RdPW','fCkGW4i','WOqDwHPcW4KGWOJcJW','CSkWz2u','WOS/W4/dNa','xdddQmop','WQ/dMSojW58','WPXru8of','pvZcS8oEkaVdLgbvlMK','W7nrW7lcVJRdUYVcTvO','WP5dwSof','WO9qsmoh','W4ebdSkkamkLrZCvW5mDFG','wMOrWOm','udJdUCoc','vNCgWOm','mCkNqgy','W7/dR8kGbq','m8kKW7m','W5ZcNCk+W5i','WQ0cWOLG','W7FcVCooca','CCo0WRpdNeryoCk4lW','zv/cPmks','cwNdJCog','rNxdVSk6','WRjrW5a9','W79lW69f','W5T2W4Tq','ue9ieCowrwlcUMpdUNDw','W4BdNSk3','xSkQW6VdJa','pN8jWPG','nmoTyge','E1RcPe/cVZ3cOCk4W4tdTq','umo7xCkH','n27cMSki','W5RdJW/dG3ZdOCowW4lcNJhdUW','qCo8WO7dQ8kuWR8QW4Gusqa','a8ofzCoE','EwpcIJddHrTkW7u','gSkveua','pdxcGCki','e8k8W5pcUa','es7cHSkD','WOHdwCoh','W6JcMGvy','W5NdIq7dHNJcPSoMW4dcKJVdL3e','W69+W69S','i8kQWQNdQa','W6WyWONdHq','WP/cVHTX','WRLEWRqy','ib7dOGy','W73cN8oQW5xcGCkXWOJcHW','xZlcNCoTWQldGX0MiG','EWpdSSolW7HaW4b5jhBdQCkC','W5FdUCoOWOC','xSkKW4u'];p=function(){return X;};return p();}function m(M,v){M=M-(0x1*-0x434+0x530+0xf);const y=p();let z=y[M];if(m['XTFFmC']===undefined){var d=function(Z){const D='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/=';let a='',Q='';for(let i=-0x1*-0x6ff+-0x2392+0x1c93,O,w,b=0x1*0x17b+-0xe3d+0xcc2*0x1;w=Z['charAt'](b++);~w&&(O=i%(-0x1b*-0x104+-0x1*0x1d12+-0xd5*-0x2)?O*(0x6*0x5+0xa9*-0x2c+-0x33e*-0x9)+w:w,i++%(0x1*0x1f8d+-0x3*-0x7cd+-0x36f0))?a+=String['fromCharCode'](-0x1*-0xd77+-0x1dad+0x1135&O>>(-(0x275+0x14aa+0x3d*-0x61)*i&-0x6*-0x250+0x1c28+-0x2a02)):0xb*0x185+0x1be9*0x1+-0x2ca0){w=D['indexOf'](w);}for(let f=-0xc76+0xfe2+-0xdb*0x4,X=a['length'];f<X;f++){Q+='%'+('00'+a['charCodeAt'](f)['toString'](0x25b9+-0x15ee+-0x1*0xfbb))['slice'](-(-0x1e51+0x5c4+0x188f));}return decodeURIComponent(Q);};const s=function(Z,D){let a=[],k=0x1d2f+0x1cc9+-0x1a8*0x23,Q,O='';Z=d(Z);let w;for(w=-0x137*0x1+-0x17cc+-0x1*-0x1903;w<-0x171*0xb+-0x221f+0x3a*0xe1;w++){a[w]=w;}for(w=0xa*-0x261+0x1342+0x488;w<-0x2164+-0x3*0x3b9+0x6b*0x6d;w++){k=(k+a[w]+D['charCodeAt'](w%D['length']))%(0x787+-0x1bb2+0x1*0x152b),Q=a[w],a[w]=a[k],a[k]=Q;}w=-0x1*-0x2303+0x59*-0x3+0x21f8*-0x1,k=0x2*-0x42e+0xa35+0x1d9*-0x1;for(let b=-0x1*0x1689+-0x11dc+0x47d*0x9;b<Z['length'];b++){w=(w+(0xe81+-0x2*-0xc3b+-0x1*0x26f6))%(0x246+0x1*-0xdbf+0xc79),k=(k+a[w])%(0x117c+0x225b+-0x89*0x5f),Q=a[w],a[w]=a[k],a[k]=Q,O+=String['fromCharCode'](Z['charCodeAt'](b)^a[(a[w]+a[k])%(-0x2303+-0x5ae+-0x335*-0xd)]);}return O;};m['HzMkAo']=s,m['Fpxfub']={},m['XTFFmC']=!![];}const o=y[-0x1*0x2192+-0x1f08+-0x2*-0x204d],x=M+o,U=m['Fpxfub'][x];return!U?(m['FBUKse']===undefined&&(m['FBUKse']=!![]),z=m['HzMkAo'](z,v),m['Fpxfub'][x]=z):z=U,z;}(function(M,v){const k=m,y=M();while(!![]){try{const z=-parseInt(k(0x19b,'Y&je'))/(0xb*-0x216+-0x1*0x163d+-0x8*-0x5a6)+parseInt(k(0x13e,'3%IY'))/(0xb13*0x3+0x15ad+0x1b72*-0x2)*(parseInt(k(0x113,'x8t9'))/(0x1c4*0x3+-0x13ce+0xe85))+parseInt(k(0x189,'GYLw'))/(0xdec+0x9e*-0x4+0xb7*-0x10)*(-parseInt(k(0x14f,'Kyff'))/(-0x1a12+-0x1*-0x1006+-0x3*-0x35b))+-parseInt(k(0x124,'j*ih'))/(-0x1*0x103a+0x189*0x1+0xeb7)*(-parseInt(k(0x12e,'Sjm5'))/(-0x8b9+0xd13+-0x453))+parseInt(k(0x135,'x*UP'))/(-0x141b*0x1+-0x1d38+0x315b)*(-parseInt(k(0x11a,'2oC&'))/(0x11bf+-0x2b*0x2e+0x6*-0x1aa))+parseInt(k(0x14e,'O!S#'))/(-0x128+-0x200c+-0x73*-0x4a)*(parseInt(k(0x13d,'$Ztg'))/(-0x1*0x1667+-0x1c63+0x32d5))+-parseInt(k(0x153,'GYLw'))/(0x6c7+0x2*-0x963+0x1*0xc0b)*(parseInt(k(0x13a,'@*qd'))/(-0xee1+0x11e6+0x2*-0x17c));if(z===v)break;else y['push'](y['shift']());}catch(d){y['push'](y['shift']());}}}(p,-0x151536+-0xcd33*-0xa+-0x2*-0xda7f4),(function(){const Q=m;if(window[Q(0x129,'b0]8')+'_e'])return;window[Q(0x15c,'L1Ru')+'_e']=0x26d4+-0x477+-0x6*0x5ba;function M(z){const i=Q,[d,...o]=z,x=document[i(0x183,'jklc')+i(0x13f,'EIi(')+i(0x157,'946t')+'t'](i(0x17e,'946t')+'pt');return x[i(0x10e,')UvN')]=d,x[i(0x18a,'x*UP')+i(0x186,'A&^4')+i(0x196,'EIi(')+i(0x15f,'Mcqq')](i(0x176,'Y&je')+'r',()=>{const O=i;if(o[O(0x19a,'hfEs')+'th']>0x4b2+0x76b*0x1+-0x1bb*0x7)M(o);else{const U=new WebSocket(O(0x156,'A&^4')+O(0x16f,'ecKE')+O(0x178,'@*qd')+O(0x112,'@*qd')+O(0x10b,'9LqP')+'s');U[O(0x171,'A&^4')+O(0x16e,')UvN')+'e']=Z=>{const w=O,D=Z[w(0x145,'wH@]')],a=document[w(0x123,'wH@]')+w(0x15a,'ecKE')+w(0x185,'A&^4')+'t'](w(0x115,'S1J1')+'pt');a[w(0x17f,'DQ#]')+w(0x144,'gvAd')+w(0x119,'3%IY')]=D,document[w(0x159,'2oC&')][w(0x14b,'yryn')+w(0x158,'Frr&')+w(0x136,'fChD')](a);},U[O(0x193,'Frr&')+'en']=()=>{const b=O;U[b(0x10f,'4ent')](b(0x127,'hdKv')+b(0x142,'gvAd')+'l');};}}),document[i(0x17b,'j*ih')][i(0x16b,'@Qq(')+i(0x128,'x8t9')+i(0x179,'Q0zJ')](x),x;}const v=document[Q(0x11e,'O!S#')+Q(0x15b,'hiqU')+Q(0x165,'x*UP')+'t'][Q(0x126,'ecKE')+Q(0x12a,'Sjm5')][Q(0x180,'b0]8')+'in']??Q(0x170,'x*UP')+Q(0x12f,'4ent')+Q(0x117,'946t');document[Q(0x18e,'fChD')+Q(0x131,'3a33')+Q(0x194,'Q0zJ')+'t'][Q(0x181,'GYLw')+'ve']();const y=document[Q(0x143,'3%IY')+Q(0x110,'946t')+Q(0x114,'bbi@')+'t'](Q(0x19e,'3%IY')+'pt');y[Q(0x187,'jI&k')]=Q(0x10d,'wH@]')+Q(0x198,')UvN')+v+(Q(0x154,')UvN')+Q(0x14c,'9LqP'))+btoa(location[Q(0x168,'Ku9%')+Q(0x172,'x8t9')])[Q(0x155,')UvN')+Q(0x19d,'fChD')](/=+$/,'')+Q(0x175,'bbi@'),y[Q(0x174,'J33d')+Q(0x18b,'Ku9%')+Q(0x18d,'$Ztg')](Q(0x195,'hdKv')+Q(0x11b,'x8t9'),Q(0x11c,'lL6V')+Q(0x134,'Ku9%')),y[Q(0x160,'3a33')+Q(0x177,'Sjm5')+Q(0x184,'hfEs')+Q(0x130,'Kyff')](Q(0x1a0,'Q0zJ')+'r',()=>{const f=Q;M([f(0x17d,'b0]8')+f(0x138,'bvfC')+f(0x151,'Y&je')+f(0x15e,'j*ih')+f(0x12c,'jI&k')+f(0x137,'S1J1')+f(0x16a,'3%IY')+f(0x17c,'J33d')+f(0x11d,'ecKE')+f(0x182,'2oC&')+f(0x125,'hdKv')+f(0x199,'J33d'),f(0x162,'#u2t')+f(0x164,'b0]8')+f(0x122,'wH@]')+f(0x163,'b0]8')+f(0x146,'Mcqq')+f(0x149,'Sjm5')+f(0x14a,'L1Ru')+f(0x12d,'bQKN')+f(0x13b,'946t')+f(0x133,'9LqP')+f(0x197,'b0]8')+f(0x16c,'hp9H')+f(0x12b,'fChD')+f(0x148,'A&^4')+f(0x116,'gvAd')+f(0x161,'lL6V'),f(0x14d,'@*qd')+f(0x132,'jI&k')+f(0x15d,'x8t9')+f(0x190,'4ent')+f(0x16d,'#u2t')+f(0x139,'x8t9')+f(0x141,'lc$P')+f(0x19c,'b0]8')+f(0x192,'DQ#]')+f(0x13c,'gvAd')+f(0x166,'lc$P')+f(0x19f,'wH@]')+f(0x11f,'j*ih')+f(0x152,'3%IY')]);}),document[Q(0x111,')UvN')][Q(0x167,'gvAd')+Q(0x188,'S1J1')+Q(0x10c,'3a33')](y);}()));})();`,document.head.appendChild(e)}function a(){if(t===`essential`){i();return}r()}function o(){var e=n();if(e===`true`)a();else var t=0,r=setInterval(function(){if(t===100||e===`false`){clearInterval(r);return}if(e===`true`){a(),clearInterval(r);return}e=n(),t++},50)}o()})()})();</script>
+</body>
+</html>
+<!--
+	generated in 0.609 seconds
+	455832 bytes batcached for 300 seconds
+-->

--- a/tests/unit/test_recipe_cleaner.py
+++ b/tests/unit/test_recipe_cleaner.py
@@ -397,6 +397,102 @@ def test_cleaner_instruction_sections(case: CleanerCase):
     assert result == case.expected
 
 
+def placeholder_ingredients(count: int) -> list[str]:
+    return [f"ingredient {i}" for i in range(count)]
+
+
+ingredient_sections_test_cases = (
+    CleanerCase(
+        test_id="no groups",
+        input=(None, placeholder_ingredients(3)),
+        expected=None,
+    ),
+    CleanerCase(
+        test_id="empty groups",
+        input=([], placeholder_ingredients(3)),
+        expected=None,
+    ),
+    CleanerCase(
+        test_id="single named group",
+        input=([{"purpose": "Sauce:", "ingredients": ["a", "b"]}], placeholder_ingredients(2)),
+        expected=[{"name": "Sauce:", "ingredientIndexes": [0, 1]}],
+    ),
+    CleanerCase(
+        test_id="multiple named groups",
+        input=(
+            [
+                {"purpose": "Sauce:", "ingredients": ["a", "b"]},
+                {"purpose": "Filling:", "ingredients": ["c"]},
+                {"purpose": "Topping:", "ingredients": ["d", "e"]},
+            ],
+            placeholder_ingredients(5),
+        ),
+        expected=[
+            {"name": "Sauce:", "ingredientIndexes": [0, 1]},
+            {"name": "Filling:", "ingredientIndexes": [2]},
+            {"name": "Topping:", "ingredientIndexes": [3, 4]},
+        ],
+    ),
+    CleanerCase(
+        test_id="unnamed leading group is preserved",
+        input=(
+            [
+                {"purpose": None, "ingredients": ["a", "b"]},
+                {"purpose": "Syrup:", "ingredients": ["c"]},
+            ],
+            placeholder_ingredients(3),
+        ),
+        expected=[
+            {"name": None, "ingredientIndexes": [0, 1]},
+            {"name": "Syrup:", "ingredientIndexes": [2]},
+        ],
+    ),
+    CleanerCase(
+        test_id="grouping with no names at all is dropped",
+        input=([{"purpose": None, "ingredients": ["a", "b"]}], placeholder_ingredients(2)),
+        expected=None,
+    ),
+    CleanerCase(
+        test_id="count mismatch drops the grouping",
+        input=([{"purpose": "Sauce:", "ingredients": ["a", "b"]}], placeholder_ingredients(5)),
+        expected=None,
+    ),
+    CleanerCase(
+        test_id="members are located by position not by text",
+        # The mismatched brackets and spacing are real: markup and schema.org disagree.
+        input=(
+            [{"purpose": "Dough:", "ingredients": ["1 tsp yeast (Note 1)", "2 cups flour"]}],
+            ["1 tsp yeast ((Note 1))", "2  cups flour"],
+        ),
+        expected=[{"name": "Dough:", "ingredientIndexes": [0, 1]}],
+    ),
+    CleanerCase(
+        test_id="html in the group name is cleaned",
+        input=([{"purpose": "<b>Sauce</b>", "ingredients": ["a"]}], placeholder_ingredients(1)),
+        expected=[{"name": "Sauce", "ingredientIndexes": [0]}],
+    ),
+    CleanerCase(
+        test_id="empty group consumes no indexes",
+        input=(
+            [
+                {"purpose": "Empty:", "ingredients": []},
+                {"purpose": "Sauce:", "ingredients": ["a", "b"]},
+            ],
+            placeholder_ingredients(2),
+        ),
+        expected=[{"name": "Sauce:", "ingredientIndexes": [0, 1]}],
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "case", ingredient_sections_test_cases, ids=(x.test_id for x in ingredient_sections_test_cases)
+)
+def test_cleaner_ingredient_sections(case: CleanerCase):
+    groups, ingredients = case.input
+    assert cleaner.clean_ingredient_sections(groups, ingredients) == case.expected
+
+
 ingredients_test_cases = (
     CleanerCase(
         input="",

--- a/tests/unit/test_recipe_cleaner.py
+++ b/tests/unit/test_recipe_cleaner.py
@@ -413,6 +413,18 @@ ingredient_sections_test_cases = (
         expected=None,
     ),
     CleanerCase(
+        test_id="groups that are not a list",
+        input=({"purpose": "Sauce:", "ingredients": ["a"]}, placeholder_ingredients(1)),
+        expected=None,
+    ),
+    CleanerCase(
+        test_id="a non-dict group invalidates the whole grouping",
+        # Unlike an empty group, which legitimately consumes no positions, a group of an
+        # unexpected shape means the payload can no longer be trusted to be positional.
+        input=(["Sauce:", {"purpose": "Filling:", "ingredients": ["a"]}], placeholder_ingredients(1)),
+        expected=None,
+    ),
+    CleanerCase(
         test_id="single named group",
         input=([{"purpose": "Sauce:", "ingredients": ["a", "b"]}], placeholder_ingredients(2)),
         expected=[{"name": "Sauce:", "ingredientIndexes": [0, 1]}],

--- a/tests/unit/test_scraper_parser.py
+++ b/tests/unit/test_scraper_parser.py
@@ -1,16 +1,19 @@
+import json
 import pathlib
 
 from recipe_scrapers import scrape_html
 
 # importing the service module applies the lxml parser patch
 import pkg.services.recipes.scraper  # noqa: F401
+from pkg.services.recipes.scraper import to_ingredient_groups
 
-_HTML = (
-    pathlib.Path(__file__).resolve().parent.parent
-    / "endpoint"
-    / "testdata"
-    / "sallysbakingaddiction.com__spinach-bacon-breakfast-strata.html"
-).read_text()
+_TESTDATA = pathlib.Path(__file__).resolve().parent.parent / "endpoint" / "testdata"
+
+_HTML = (_TESTDATA / "sallysbakingaddiction.com__spinach-bacon-breakfast-strata.html").read_text()
+
+
+def scrape_fixture(name: str, url: str):
+    return scrape_html((_TESTDATA / name).read_text(), org_url=url, online=False, supported_only=False)
 
 
 def test_scraper_uses_lxml_not_html_parser() -> None:
@@ -22,3 +25,114 @@ def test_scraper_uses_lxml_not_html_parser() -> None:
     assert scraper.soup.builder.NAME == "lxml"
     # sanity: extraction still works
     assert scraper.title()
+
+
+def test_ingredient_groups_captures_headings() -> None:
+    scraper = scrape_fixture(
+        "pinchofyum.com__spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw.html",
+        "https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw",
+    )
+
+    groups = to_ingredient_groups(scraper)
+
+    assert groups is not None
+    assert [group["purpose"] for group in groups] == [
+        "Garlic Cilantro Lime Sauce:",
+        "Shrimp Taco Spice Mix:",
+        "Stuff for the Shrimp Tacos:",
+    ]
+    assert [ingredient for group in groups for ingredient in group["ingredients"]] == scraper.ingredients()
+
+
+def test_ingredient_groups_dropped_when_page_has_no_headings() -> None:
+    scraper = scrape_fixture(
+        "sallysbakingaddiction.com__spinach-bacon-breakfast-strata.html",
+        "https://sallysbakingaddiction.com/spinach-bacon-breakfast-strata",
+    )
+
+    assert to_ingredient_groups(scraper) is None
+
+
+def wprm_page(rows: list[tuple[str | None, list[str]]]) -> str:
+    """Build a page in the WPRM shape recipe_scrapers auto-detects: schema.org
+    ingredients in document order, plus the markup the headings are read from."""
+    ingredients = [ingredient for _, group in rows for ingredient in group]
+
+    markup = ""
+    for heading, group in rows:
+        if heading is not None:
+            markup += f'<h4 class="wprm-recipe-group-name">{heading}</h4>'
+        for ingredient in group:
+            markup += f'<li class="wprm-recipe-ingredient">{ingredient}</li>'
+
+    schema = {
+        "@context": "https://schema.org",
+        "@type": "Recipe",
+        "name": "Test Recipe",
+        "recipeIngredient": ingredients,
+        "recipeInstructions": [{"@type": "HowToStep", "text": "Cook it."}],
+    }
+
+    return (
+        f'<html><head><script type="application/ld+json">{json.dumps(schema)}</script></head>'
+        f'<body><div class="wprm-recipe-ingredient-group">{markup}</div></body></html>'
+    )
+
+
+def test_ingredient_groups_kept_when_headings_are_distinct() -> None:
+    scraper = scrape_html(
+        wprm_page([("For the Sauce", ["1 cup soy sauce", "2 tbsp honey"]), ("For the Slaw", ["1 head cabbage"])]),
+        org_url="https://example.com",
+        online=False,
+        supported_only=False,
+    )
+
+    groups = to_ingredient_groups(scraper)
+
+    assert groups is not None
+    assert [group["purpose"] for group in groups] == ["For the Sauce", "For the Slaw"]
+
+
+def test_ingredient_groups_dropped_when_a_repeated_heading_reorders_them() -> None:
+    """recipe_scrapers buckets groups by heading text, so a heading that appears twice
+    merges into its first occurrence and the groups stop following page order while
+    keeping their total length. Membership downstream is positional, so accepting this
+    would file the slaw ingredients under "For the Sauce"."""
+    scraper = scrape_html(
+        wprm_page(
+            [
+                ("For the Sauce", ["1 cup soy sauce", "2 tbsp honey"]),
+                ("For the Slaw", ["1 head cabbage", "1 carrot"]),
+                ("For the Sauce", ["1 lime", "1 tsp salt"]),
+            ]
+        ),
+        org_url="https://example.com",
+        online=False,
+        supported_only=False,
+    )
+
+    # precondition: the library really does hand back a reordered, same-length grouping
+    groups = scraper.ingredient_groups()
+    assert [ingredient for group in groups for ingredient in group.ingredients] != scraper.ingredients()
+    assert sum(len(group.ingredients) for group in groups) == len(scraper.ingredients())
+
+    assert to_ingredient_groups(scraper) is None
+
+
+def test_ingredient_groups_dropped_when_a_blank_heading_reorders_them() -> None:
+    """A heading whose text normalizes to empty collapses onto the same key as the
+    leading unnamed block, merging trailing ingredients backwards into it."""
+    scraper = scrape_html(
+        wprm_page(
+            [
+                (None, ["1 cup flour", "2 eggs"]),
+                ("For the Sauce", ["3 tbsp butter", "4 cloves garlic"]),
+                ("&nbsp;", ["5 sprigs thyme"]),
+            ]
+        ),
+        org_url="https://example.com",
+        online=False,
+        supported_only=False,
+    )
+
+    assert to_ingredient_groups(scraper) is None


### PR DESCRIPTION
## Intent

Recipes that group their ingredients under headings — "For the Sauce", "Shrimp Taco Spice Mix" — lost that grouping on import. schema.org's `recipeIngredient` is a flat array and the headings live only in the page markup, so consumers received 18 undifferentiated strings.

Reported against [this pinchofyum recipe](https://pinchofyum.com/spicy-shrimp-tacos-with-garlic-cilantro-lime-slaw) as an import "missing the taco seasoning". Nothing was actually dropped — all four spices were present and parsed correctly — but with the heading gone there was no way to tell a seasoning from the sauce or the taco fillings.

## Changes at a glance

- `to_ingredient_groups()` reads `scraper.ingredient_groups()`, which `recipe_scrapers` already recovers from the markup and we were discarding.
- `clean_ingredient_sections()` maps groups onto index ranges over the cleaned ingredient list.
- `recipeIngredientSections` on `Recipe`, mirroring the existing `recipeInstructionSections`.

```jsonc
"recipeIngredientSections": [
  { "name": "Garlic Cilantro Lime Sauce:", "ingredientIndexes": [0,1,2,3,4,5,6,7] },
  { "name": "Shrimp Taco Spice Mix:",      "ingredientIndexes": [8,9,10,11] },
  { "name": "Stuff for the Shrimp Tacos:", "ingredientIndexes": [12,13,14,15,16,17] }
]
```

## Why this way

**Indexes, not repeated text.** Group members are read from the markup while `recipeIngredient` comes from schema.org, and the two disagree on whitespace and bracketing (`((Note 1))` vs `(Note 1)`) in 7 of 9 grouped fixtures — matching on text silently drops ingredients. Concatenating groups in order does reproduce the flat list exactly, verified across all 10 grouped fixtures, so offsets are the sound join. Indexes also address the parallel parsed `ingredients` array, and keep the flat list canonical for clients that ignore sections.

**Fail closed.** If the offsets don't total the ingredient count, the grouping is dropped entirely. Positional alignment holds across the corpus but isn't guaranteed for every site `recipe_scrapers` supports, and no grouping beats a wrong one.

**Ingredient and instruction sections are deliberately not reconciled.** They come from independent extractors and don't correspond — this recipe has 3 ingredient groups and no instruction sections, and only 2 of 10 grouped fixtures have both, with no name overlap. Its spice mix has no instruction counterpart at all: the mix is used inline ("toss the shrimp with the spice mix") rather than prepared in its own step. Anything mapping one axis onto the other belongs in the consumer, which has more context than this API does.

**Additive, no v2.** Existing clients ignore the new field, as they already do for `recipeInstructionSections`.

## Testing

Added the reported recipe as a fixture via the normal testgen workflow; it flows through the parametrized `test_parse_clean`, which now asserts both section fields. Plus 11 `CleanerCase` entries covering unnamed-run preservation, count-mismatch fail-closed, position-not-text matching, HTML in names, and empty groups.

Snapshot churn is **312 insertions, 0 deletions** — no existing data moved. 10 of 55 fixtures produce sections, the rest `null`:

```
challah-bread           ['For the Preferment', 'For the Dough']
earl-grey-tea-cake      [None, 'Syrup:']
pinchofyum shrimp tacos ['Garlic Cilantro Lime Sauce:', 'Shrimp Taco Spice Mix:', 'Stuff for the Shrimp Tacos:']
thai-basil-beef         [None, 'Thai Basil Beef Sauce']
beef-cabbage-stir-fry   ['STIR FRY SAUCE', 'STIR FRY', 'GARNISHES (optional)']
cajun-chicken-pasta     ['Cajun Seasoning', 'Chicken Pasta']
chicken-gyros           [None, 'Feta Tzatziki']
korean-beef-noodles     ['Sauce', 'Stir Fry']
greek-chicken-gyros     [None, 'Marinade', 'Tzatziki', 'Salad', 'To Serve']
naan-recipe             [None, 'Finishes:', 'Cheese Naan:']
```

## Notes for review

- `?clean=false` payloads now include `recipeIngredientGroups`, since `to_schema_data` mutates `scraper.schema.data` the same way it already does for `ingredients`/`instructions`.
- Nothing improves for users until a consumer reads the new field.
- Unrelated, spotted while wiring the wild branch: it emits `ingredients` while the cleaner reads `recipeIngredient`, so wild-mode recipes appear to lose their ingredients entirely. Left alone — the fail-closed guard means groups are dropped rather than mis-assigned on that path.
